### PR TITLE
add modis albedo wsa diff 2015-22 dataset json

### DIFF
--- a/ingestion-data/collections/modis-albedo-wsa-diff-2015-2022.json
+++ b/ingestion-data/collections/modis-albedo-wsa-diff-2015-2022.json
@@ -1,5 +1,5 @@
 {
-    "collection": "modis_diff",
+    "collection": "modis-albedo-wsa-diff-2015-2022",
     "title": "Camp Fire Domain: MODIS WSA Albedo Difference",
     "spatial_extent": {
         "xmin": -122.21,
@@ -17,12 +17,12 @@
     "is_periodic": true,
     "time_density": "year",
     "sample_files": [
-        "s3://veda-data-store-staging/modis_diff/campfire_albedo_wsa_difference_2015_2022.tif"
+        "s3://veda-data-store-staging/modis-albedo-wsa-diff-2015-2022/campfire_albedo_wsa_difference_2015_2022.tif"
     ],
     "discovery_items": [
         {
             "discovery": "s3",
-            "prefix": "modis_diff/",
+            "prefix": "modis-albedo-wsa-diff-2015-2022/",
             "bucket": "veda-data-store-staging",
             "filename_regex": "(.*)campfire_albedo_wsa_difference_2015_2022.tif$"
         }

--- a/ingestion-data/collections/modis-albedo-wsa-diff-2015-2022.json
+++ b/ingestion-data/collections/modis-albedo-wsa-diff-2015-2022.json
@@ -1,0 +1,30 @@
+{
+    "collection": "modis_diff",
+    "title": "Camp Fire Domain: MODIS WSA Albedo Difference",
+    "spatial_extent": {
+        "xmin": -122.21,
+        "ymin": 39.33,
+        "xmax": -120.91,
+        "ymax": 40.22
+    },
+    "temporal_extent": {
+        "startdate": "2022-12-31T00:00:00Z",
+        "enddate": "2022-12-31T23:59:59Z"
+    },
+    "data_type": "cog",
+    "license": "CC0",
+    "description": "MODIS WSA Albedo difference from a three-year average of 2015 to 2018 subtracted from a three-year average of 2019-2022. These tri-annual averages represent periods before and after the fire.",
+    "is_periodic": true,
+    "time_density": "year",
+    "sample_files": [
+        "s3://veda-data-store-staging/modis_diff/campfire_albedo_wsa_difference_2015_2022.tif"
+    ],
+    "discovery_items": [
+        {
+            "discovery": "s3",
+            "prefix": "modis_diff/",
+            "bucket": "veda-data-store-staging",
+            "filename_regex": "(.*)campfire_albedo_wsa_difference_2015_2022.tif$"
+        }
+    ]
+}


### PR DESCRIPTION
This PR supports the movement of the `Camp Fire Albedo WSA 2015 - 2002 difference` dataset to the Staging API.

This is the second of four datasets to be uploaded from issue https://github.com/NASA-IMPACT/veda-data/issues/24