### PR TITLE
add lst day diff 2015-2022 dataset json

### DIFF
--- a/ingestion-data/collections/modis-lst-day-diff-2015-2022.json
+++ b/ingestion-data/collections/modis-lst-day-diff-2015-2022.json
@@ -1,0 +1,30 @@
+{
+    "collection": "modis_diff",
+    "title": "Camp Fire Domain: MODIS LST Day Difference",
+    "spatial_extent": {
+        "xmin": -122.21,
+        "ymin": 39.33,
+        "xmax": -120.91,
+        "ymax": 40.22
+    },
+    "temporal_extent": {
+        "startdate": "2022-12-31T00:00:00Z",
+        "enddate": "2022-12-31T23:59:59Z"
+    },
+    "data_type": "cog",
+    "license": "CC0",
+    "description": "MODIS LST Day difference from a three-year average of 2015 to 2018 subtracted from a three-year average of 2019-2022. These tri-annual averages represent periods before and after the fire.",
+    "is_periodic": true,
+    "time_density": "year",
+    "sample_files": [
+        "s3://veda-data-store-staging/modis_diff/campfire_lst_day_difference_2015_2022.tif"
+    ],
+    "discovery_items": [
+        {
+            "discovery": "s3",
+            "prefix": "modis_diff/",
+            "bucket": "veda-data-store-staging",
+            "filename_regex": "(.*)campfire_lst_day_difference_2015_2022.tif$"
+        }
+    ]
+}

--- a/ingestion-data/collections/modis-lst-day-diff-2015-2022.json
+++ b/ingestion-data/collections/modis-lst-day-diff-2015-2022.json
@@ -1,5 +1,5 @@
 {
-    "collection": "modis_diff",
+    "collection": "modis-lst-day-diff-2015-2022",
     "title": "Camp Fire Domain: MODIS LST Day Difference",
     "spatial_extent": {
         "xmin": -122.21,
@@ -17,12 +17,12 @@
     "is_periodic": true,
     "time_density": "year",
     "sample_files": [
-        "s3://veda-data-store-staging/modis_diff/campfire_lst_day_difference_2015_2022.tif"
+        "s3://veda-data-store-staging/modis-lst-day-diff-2015-2022/campfire_lst_day_difference_2015_2022.tif"
     ],
     "discovery_items": [
         {
             "discovery": "s3",
-            "prefix": "modis_diff/",
+            "prefix": "modis-lst-day-diff-2015-2022/",
             "bucket": "veda-data-store-staging",
             "filename_regex": "(.*)campfire_lst_day_difference_2015_2022.tif$"
         }


### PR DESCRIPTION
This PR supports the movement of the `Camp Fire LST Day Difference 2015 - 2002 difference` dataset to the Staging API.

This is the third of four datasets to be uploaded from issue https://github.com/NASA-IMPACT/veda-data/issues/24