### PR TITLE
fix: houston-urbanization discovery prefix fix

### DIFF
--- a/ingestion-data/production/discovery-items/houston-urbanization.json
+++ b/ingestion-data/production/discovery-items/houston-urbanization.json
@@ -2,7 +2,7 @@
     "collection": "houston-urbanization",
     "bucket": "veda-data-store",
     "prefix": "houston-urbanization/",
-    "filename_regex": "^(.*)HOUS_DFAL_urbanization",
+    "filename_regex": "^(.*)HOUS_DFAL_urbanization.*[.]tif$",
     "discovery": "s3",
     "upload": false
 }


### PR DESCRIPTION
# What
Made discovery-items prefix more specific to avoid .aux.tif that may have caused the ingest to error