### PR TITLE
Fix nightlights-hd-monthly discovery config

### DIFF
--- a/ingestion-data/production/discovery-items/nightlights-hd-monthly.json
+++ b/ingestion-data/production/discovery-items/nightlights-hd-monthly.json
@@ -2,7 +2,7 @@
     "collection": "nightlights-hd-monthly",
     "prefix": "nightlights-hd-monthly/",
     "bucket": "veda-data-store",
-    "filename_regex": "^(.*)(Barcelona|Lima|Paris|Milan|Marseille|Beijing|Dhaka_Dhaka-city|Ghent|Fukuoka_Fukuoka-city|Tokyo-23Wards|Aichi_Nagoya-city|Dunkirk|Madrid|Colombo|Gdynia|Hamburg|Osaka_Osaka-city|Singapore|Venice|Auckland|Genoa|Kyoto_Kyoto-city|London|Rome|Amsterdam|Hokkaido_Sapporo)(.*).tif$",
+    "filename_regex": "^(.*)(Barcelona|Lima|Paris|Milan|Marseille|Beijing|Dhaka_Dhaka-city|Ghent|Fukuoka_Fukuoka-city|Tokyo-23Wards|Aichi_Nagoya-city|Dunkirk|Madrid|Colombo|Gdynia|Hamburg|Osaka_Osaka-city|Singapore|Venice|Auckland|Genoa|Kyoto_Kyoto-city|London|Rome|Amsterdam|Hokkaido_Sapporo|be|du|gh|la|ny|sf|tk|wu)(.*).tif$",
     "discovery": "s3",
     "datetime_range": "month"
 }


### PR DESCRIPTION
Extend nightlights-hd-monthly.json discover config regex to catch abbreviated place names