### PR TITLE
feat: add thumbnail asset metadata to production collections

### DIFF
--- a/ingestion-data/production/collections/CMIP245-winter-median-pr.json
+++ b/ingestion-data/production/collections/CMIP245-winter-median-pr.json
@@ -80,5 +80,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Nisqually glacier)",
+            "href": "https://thumbnails.openveda.cloud/CMIP-winter-median.jpeg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/CMIP245-winter-median-ta.json
+++ b/ingestion-data/production/collections/CMIP245-winter-median-ta.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Nisqually glacier)",
+            "href": "https://thumbnails.openveda.cloud/CMIP-winter-median.jpeg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/CMIP585-winter-median-pr.json
+++ b/ingestion-data/production/collections/CMIP585-winter-median-pr.json
@@ -80,5 +80,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Nisqually glacier)",
+            "href": "https://thumbnails.openveda.cloud/CMIP-winter-median.jpeg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/CMIP585-winter-median-ta.json
+++ b/ingestion-data/production/collections/CMIP585-winter-median-ta.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Nisqually glacier)",
+            "href": "https://thumbnails.openveda.cloud/CMIP-winter-median.jpeg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1A_Combustion_Mobile.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1A_Combustion_Mobile.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1A_Combustion_Stationary.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1A_Combustion_Stationary.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Abandoned_Coal.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Abandoned_Coal.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Dominik Vanyi](https://unsplash.com/photos/Mk2ls9UBO2E) (Machinery working a very large coal mine)",
+            "href": "https://thumbnails.openveda.cloud/epa-coal-mines--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Coal_Mining_Surface.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Coal_Mining_Surface.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Dominik Vanyi](https://unsplash.com/photos/Mk2ls9UBO2E) (Machinery working a very large coal mine)",
+            "href": "https://thumbnails.openveda.cloud/epa-coal-mines--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Coal_Mining_Underground.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B1a_Coal_Mining_Underground.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Dominik Vanyi](https://unsplash.com/photos/Mk2ls9UBO2E) (Machinery working a very large coal mine)",
+            "href": "https://thumbnails.openveda.cloud/epa-coal-mines--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B2a_Petroleum.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B2a_Petroleum.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Patrick Hendry](https://unsplash.com/photos/6xeDIZgoPaw) (Punk style picture of a petroleum refinery)",
+            "href": "https://thumbnails.openveda.cloud/epa-petroleum--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Distribution.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Distribution.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [American Public Power Association](https://unsplash.com/photos/TF-DL_2L1JM) (Gas processing plant at dusk)",
+            "href": "https://thumbnails.openveda.cloud/epa-natural-gas--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Processing.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Processing.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [American Public Power Association](https://unsplash.com/photos/TF-DL_2L1JM) (Gas processing plant at dusk)",
+            "href": "https://thumbnails.openveda.cloud/epa-natural-gas--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Production.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Production.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [American Public Power Association](https://unsplash.com/photos/TF-DL_2L1JM) (Gas processing plant at dusk)",
+            "href": "https://thumbnails.openveda.cloud/epa-natural-gas--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Transmission.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_1B2b_Natural_Gas_Transmission.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [American Public Power Association](https://unsplash.com/photos/TF-DL_2L1JM) (Gas processing plant at dusk)",
+            "href": "https://thumbnails.openveda.cloud/epa-natural-gas--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_2B5_Petrochemical_Production.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_2B5_Petrochemical_Production.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_2C2_Ferroalloy_Production.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_2C2_Ferroalloy_Production.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_4A_Enteric_Fermentation.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_4A_Enteric_Fermentation.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_4B_Manure_Management.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_4B_Manure_Management.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_4C_Rice_Cultivation.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_4C_Rice_Cultivation.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_4F_Field_Burning.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_4F_Field_Burning.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_5_Forest_Fires.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_5_Forest_Fires.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_6A_Landfills_Industrial.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_6A_Landfills_Industrial.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Antoine GIRET](https://unsplash.com/photos/7_TSzqJms4w) (Mountain of rubbish and garbage on the beach by the sea)",
+            "href": "https://thumbnails.openveda.cloud/epa-waste--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_6A_Landfills_Municipal.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_6A_Landfills_Municipal.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Antoine GIRET](https://unsplash.com/photos/7_TSzqJms4w) (Mountain of rubbish and garbage on the beach by the sea)",
+            "href": "https://thumbnails.openveda.cloud/epa-waste--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_6B_Wastewater_Treatment_Domestic.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_6B_Wastewater_Treatment_Domestic.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Antoine GIRET](https://unsplash.com/photos/7_TSzqJms4w) (Mountain of rubbish and garbage on the beach by the sea)",
+            "href": "https://thumbnails.openveda.cloud/epa-waste--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_6B_Wastewater_Treatment_Industrial.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_6B_Wastewater_Treatment_Industrial.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Antoine GIRET](https://unsplash.com/photos/7_TSzqJms4w) (Mountain of rubbish and garbage on the beach by the sea)",
+            "href": "https://thumbnails.openveda.cloud/epa-waste--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-annual-emissions_6D_Composting.json
+++ b/ingestion-data/production/collections/EPA-annual-emissions_6D_Composting.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Antoine GIRET](https://unsplash.com/photos/7_TSzqJms4w) (Mountain of rubbish and garbage on the beach by the sea)",
+            "href": "https://thumbnails.openveda.cloud/epa-waste--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-daily-emissions_5_Forest_Fires.json
+++ b/ingestion-data/production/collections/EPA-daily-emissions_5_Forest_Fires.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_1A_Combustion_Stationary.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_1A_Combustion_Stationary.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Harry Schaefer / Documerica](https://unsplash.com/photos/EjSw6WdnLRA) (Orange Ford truck leaving a Union Carbide ferro-alloy plant. Shot on May 1975)",
+            "href": "https://thumbnails.openveda.cloud/epa-other--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_1B2a_Petroleum.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_1B2a_Petroleum.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Patrick Hendry](https://unsplash.com/photos/6xeDIZgoPaw) (Punk style picture of a petroleum refinery)",
+            "href": "https://thumbnails.openveda.cloud/epa-petroleum--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_1B2b_Natural_Gas_Production.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_1B2b_Natural_Gas_Production.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [American Public Power Association](https://unsplash.com/photos/TF-DL_2L1JM) (Gas processing plant at dusk)",
+            "href": "https://thumbnails.openveda.cloud/epa-natural-gas--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_4B_Manure_Management.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_4B_Manure_Management.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_4C_Rice_Cultivation.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_4C_Rice_Cultivation.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/EPA-monthly-emissions_4F_Field_Burning.json
+++ b/ingestion-data/production/collections/EPA-monthly-emissions_4F_Field_Burning.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [James Baltz](https://unsplash.com/photos/jAt6cN6zl8M) (Tractors tending a corn field)",
+            "href": "https://thumbnails.openveda.cloud/epa-agriculture--cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/IS2SITMOGR4-cog.json
+++ b/ingestion-data/production/collections/IS2SITMOGR4-cog.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Matt Broch](https://unsplash.com/photos/bwD3GLrV4pY) (Huge chunk of ice calving into the sea below)",
+            "href": "https://thumbnails.openveda.cloud/sea-ice-thick--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/MO_NPP_npp_vgpm.json
+++ b/ingestion-data/production/collections/MO_NPP_npp_vgpm.json
@@ -66,5 +66,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Karl Callwood](https://unsplash.com/photos/Ko1sGLhZm5w) (Rocky ocean shore)",
+            "href": "https://thumbnails.openveda.cloud/ocean-production--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/OMI_trno2-COG.json
+++ b/ingestion-data/production/collections/OMI_trno2-COG.json
@@ -66,5 +66,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mick Truyts](https://unsplash.com/photos/x6WQeNYJC1w) (Power plant shooting steam at the sky)",
+            "href": "https://thumbnails.openveda.cloud/no2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/OMSO2PCA-COG.json
+++ b/ingestion-data/production/collections/OMSO2PCA-COG.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (2018 Social Vulnerability Index (SVI) based on minority status and language score)",
+            "href": "https://thumbnails.openveda.cloud/so2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/bangladesh-landcover-2001-2020.json
+++ b/ingestion-data/production/collections/bangladesh-landcover-2001-2020.json
@@ -110,5 +110,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [USGS](https://unsplash.com/photos/d59NHNtT_Ss) (Annual land cover maps for 2001 and 2020 (Bangladesh))",
+            "href": "https://thumbnails.openveda.cloud/bangladesh-landcover-2001-2020--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/barc-thomasfire.json
+++ b/ingestion-data/production/collections/barc-thomasfire.json
@@ -81,5 +81,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/blue-tarp-detection.json
+++ b/ingestion-data/production/collections/blue-tarp-detection.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (Blue tarp detections for Jefferson Parish, LA on February 12, 2022)",
+            "href": "https://thumbnails.openveda.cloud/ps-bluetarp--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/blue-tarp-planetscope.json
+++ b/ingestion-data/production/collections/blue-tarp-planetscope.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (Blue tarp detections for Jefferson Parish, LA on February 12, 2022)",
+            "href": "https://thumbnails.openveda.cloud/ps-bluetarp--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/caldor-fire-behavior.json
+++ b/ingestion-data/production/collections/caldor-fire-behavior.json
@@ -80,5 +80,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Marek Piwnicki](https://unsplash.com/photos/WiZOyYqzUss) (Hillside engulfed by a wildfire)",
+            "href": "https://thumbnails.openveda.cloud/caldor-fire--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/caldor-fire-burn-severity.json
+++ b/ingestion-data/production/collections/caldor-fire-burn-severity.json
@@ -80,5 +80,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Marek Piwnicki](https://unsplash.com/photos/WiZOyYqzUss) (Hillside engulfed by a wildfire)",
+            "href": "https://thumbnails.openveda.cloud/caldor-fire--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/campfire-albedo-wsa-diff.json
+++ b/ingestion-data/production/collections/campfire-albedo-wsa-diff.json
@@ -51,11 +51,13 @@
             ]
         }
     ],
-    "thumbnail": {
-        "title": "Thumbnail",
-        "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
-        "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
-        "type": "image/jpeg",
-        "roles": ["thumbnail"]
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+            "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/campfire-albedo-wsa-diff.json
+++ b/ingestion-data/production/collections/campfire-albedo-wsa-diff.json
@@ -50,5 +50,12 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "thumbnail": {
+        "title": "Thumbnail",
+        "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+        "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+        "type": "image/jpeg",
+        "roles": ["thumbnail"]
+    }
 }

--- a/ingestion-data/production/collections/campfire-lst-day-diff.json
+++ b/ingestion-data/production/collections/campfire-lst-day-diff.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+            "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/campfire-lst-night-diff.json
+++ b/ingestion-data/production/collections/campfire-lst-night-diff.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+            "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/campfire-ndvi-diff.json
+++ b/ingestion-data/production/collections/campfire-ndvi-diff.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+            "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/campfire-nlcd.json
+++ b/ingestion-data/production/collections/campfire-nlcd.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Engulfed hillside in California, 2021)",
+            "href": "https://thumbnails.openveda.cloud/camp-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp126.json
+++ b/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp126.json
@@ -92,5 +92,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (CMIP6 Climdex TmaxXF Screenshot)",
+            "href": "https://thumbnails.openveda.cloud/cmip6-climdex-tmaxxf-access-cm2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp245.json
+++ b/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp245.json
@@ -98,5 +98,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (CMIP6 Climdex TmaxXF Screenshot)",
+            "href": "https://thumbnails.openveda.cloud/cmip6-climdex-tmaxxf-access-cm2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp370.json
+++ b/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp370.json
@@ -98,5 +98,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (CMIP6 Climdex TmaxXF Screenshot)",
+            "href": "https://thumbnails.openveda.cloud/cmip6-climdex-tmaxxf-access-cm2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp585.json
+++ b/ingestion-data/production/collections/climdex-tmaxxf-access-cm2-ssp585.json
@@ -98,5 +98,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (CMIP6 Climdex TmaxXF Screenshot)",
+            "href": "https://thumbnails.openveda.cloud/cmip6-climdex-tmaxxf-access-cm2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/co2-diff.json
+++ b/ingestion-data/production/collections/co2-diff.json
@@ -66,5 +66,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Marek Piwnicki](https://unsplash.com/photos/WiZOyYqzUss) (Power plant shooting steam at the sky)",
+            "href": "https://thumbnails.openveda.cloud/co2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/co2-mean.json
+++ b/ingestion-data/production/collections/co2-mean.json
@@ -66,5 +66,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Marek Piwnicki](https://unsplash.com/photos/WiZOyYqzUss) (Power plant shooting steam at the sky)",
+            "href": "https://thumbnails.openveda.cloud/co2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/combined_CMIP6_daily_GISS-E2-1-G_tas_kerchunk_DEMO.json
+++ b/ingestion-data/production/collections/combined_CMIP6_daily_GISS-E2-1-G_tas_kerchunk_DEMO.json
@@ -12,7 +12,15 @@
             "data"
           ],
           "title": "zarr"
+        },
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (CMIP6 Near-Surface Air Temperature Screenshot)",
+            "href": "https://thumbnails.openveda.cloud/cmip6-tas.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
         }
+
     },    
     "extent": {
         "spatial": {

--- a/ingestion-data/production/collections/conus-reach.json
+++ b/ingestion-data/production/collections/conus-reach.json
@@ -74,5 +74,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://www.nasa.gov) (A map showing nitrate loads in the rivers of the United States on 07/01/2018)",
+            "href": "https://thumbnails.openveda.cloud/CONUS_Nitrate_07012018.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/disalexi-etsuppression.json
+++ b/ingestion-data/production/collections/disalexi-etsuppression.json
@@ -67,5 +67,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/ecco-surface-height-change.json
+++ b/ingestion-data/production/collections/ecco-surface-height-change.json
@@ -80,5 +80,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Lance Asper](https://unsplash.com/photos/3P3NHLZGCp8) (Wave crashing on a sandy beach)",
+            "href": "https://thumbnails.openveda.cloud/ecco-surface-height-change--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/eis_fire_perimeter.json
+++ b/ingestion-data/production/collections/eis_fire_perimeter.json
@@ -71,5 +71,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Matt Howard](https://unsplash.com/photos/eAKDzK4lo4o) (Forest burning at night)",
+            "href": "https://thumbnails.openveda.cloud/fire--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/facebook_population_density.json
+++ b/ingestion-data/production/collections/facebook_population_density.json
@@ -86,5 +86,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (2015 high resolution population density for Paris)",
+            "href": "https://thumbnails.openveda.cloud/fb-population--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/fldas-soil-moisture-anomalies.json
+++ b/ingestion-data/production/collections/fldas-soil-moisture-anomalies.json
@@ -63,5 +63,14 @@
             "title": "VEDA Dashboard Render Parameters"
         }
     },
-    "providers": []
+    "providers": [],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Amy McNally (Landscape in Gondar, Ethiopia)",
+            "href": "https://thumbnails.openveda.cloud/FLDAS_Dataset_Cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/frp-max-thomasfire.json
+++ b/ingestion-data/production/collections/frp-max-thomasfire.json
@@ -82,5 +82,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/geoglam.json
+++ b/ingestion-data/production/collections/geoglam.json
@@ -112,5 +112,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jean Wimmerlin](https://unsplash.com/photos/RUj5b4YXaHE) (Bird's eye view of fields)",
+            "href": "https://thumbnails.openveda.cloud/geoglam--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-cdr-raster.json
+++ b/ingestion-data/production/collections/grdi-cdr-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-filled-missing-values-count.json
+++ b/ingestion-data/production/collections/grdi-filled-missing-values-count.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-imr-raster.json
+++ b/ingestion-data/production/collections/grdi-imr-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-shdi-raster.json
+++ b/ingestion-data/production/collections/grdi-shdi-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-v1-built.json
+++ b/ingestion-data/production/collections/grdi-v1-built.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-v1-raster.json
+++ b/ingestion-data/production/collections/grdi-v1-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-vnl-raster.json
+++ b/ingestion-data/production/collections/grdi-vnl-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/grdi-vnl-slope-raster.json
+++ b/ingestion-data/production/collections/grdi-vnl-slope-raster.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jordan Opel](https://unsplash.com/photos/3VLHF9b9Plg) (Shacks along a river almost collapsing)",
+            "href": "https://thumbnails.openveda.cloud/grdi--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/hls-bais2-v2.json
+++ b/ingestion-data/production/collections/hls-bais2-v2.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [XXXXXXX](XXX) (XXX)",
+            "href": "https://thumbnails.openveda.cloud/XXX.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/hls-bais2-v2.json
+++ b/ingestion-data/production/collections/hls-bais2-v2.json
@@ -54,8 +54,8 @@
     "assets": {
         "thumbnail": {
             "title": "Thumbnail",
-            "description": "Photo by [XXXXXXX](XXX) (XXX)",
-            "href": "https://thumbnails.openveda.cloud/XXX.jpg",
+            "description": "Photo by [Matthew Thayer/AP](https://www.sfchronicle.com/travel/article/hawaii-fire-maui-lahaina-18289213.php) (Wildfire erupting over Lahaina, HI, August 8, 2023)",
+            "href": "https://thumbnails.openveda.cloud/lahaina-fire-background.jpg",
             "type": "image/jpeg",
             "roles": ["thumbnail"]
         }

--- a/ingestion-data/production/collections/hls-l30-002-ej-reprocessed.json
+++ b/ingestion-data/production/collections/hls-l30-002-ej-reprocessed.json
@@ -80,6 +80,7 @@
     "assets": {
         "thumbnail": {
             "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov) (2017 harmonized Landsat 8 shortwave infrared (SWIR) false color composite image that provides enhanced contrast to detect flood extent)",
             "href": "https://thumbnails.openveda.cloud/hls-events-ej--dataset-cover.png",
             "type": "image/png",
             "roles": ["thumbnail"]

--- a/ingestion-data/production/collections/hls-ndvi.json
+++ b/ingestion-data/production/collections/hls-ndvi.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA (Screenshot of harmonized landsat normalized difference vegetation index from September 2022)",
+            "href": "https://thumbnails.openveda.cloud/hls-ndvi.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/hls-s30-002-ej-reprocessed.json
+++ b/ingestion-data/production/collections/hls-s30-002-ej-reprocessed.json
@@ -80,6 +80,7 @@
     "assets": {
         "thumbnail": {
             "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov) (2017 harmonized Landsat 8 shortwave infrared (SWIR) false color composite image that provides enhanced contrast to detect flood extent)",
             "href": "https://thumbnails.openveda.cloud/hls-events-ej--dataset-cover.png",
             "type": "image/png",
             "roles": ["thumbnail"]

--- a/ingestion-data/production/collections/hls-swir-falsecolor-composite.json
+++ b/ingestion-data/production/collections/hls-swir-falsecolor-composite.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Matthew Thayer/AP](https://www.sfchronicle.com/travel/article/hawaii-fire-maui-lahaina-18289213.php) (Wildfire erupting over Lahaina, HI, August 8, 2023)",
+            "href": "https://thumbnails.openveda.cloud/lahaina-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-aod-diff.json
+++ b/ingestion-data/production/collections/houston-aod-diff.json
@@ -81,5 +81,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Nick van den Berg](https://unsplash.com/photos/2vb-_3t6YCM) (Smog Located In City)",
+            "href": "https://thumbnails.openveda.cloud/smog-city.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-aod.json
+++ b/ingestion-data/production/collections/houston-aod.json
@@ -81,5 +81,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Nick van den Berg](https://unsplash.com/photos/2vb-_3t6YCM) (Smog Located In City)",
+            "href": "https://thumbnails.openveda.cloud/smog-city.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-landcover.json
+++ b/ingestion-data/production/collections/houston-landcover.json
@@ -107,5 +107,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Arto Marttinen](https://unsplash.com/photos/6xh7H5tWj9c) (Sunset over Tokyo)",
+            "href": "https://thumbnails.openveda.cloud/urban-heat.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-lst-day.json
+++ b/ingestion-data/production/collections/houston-lst-day.json
@@ -84,5 +84,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Arto Marttinen](https://unsplash.com/photos/6xh7H5tWj9c) (Sunset over Tokyo)",
+            "href": "https://thumbnails.openveda.cloud/urban-heat.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-lst-diff.json
+++ b/ingestion-data/production/collections/houston-lst-diff.json
@@ -84,5 +84,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Arto Marttinen](https://unsplash.com/photos/6xh7H5tWj9c) (Sunset over Tokyo)",
+            "href": "https://thumbnails.openveda.cloud/urban-heat.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-lst-night.json
+++ b/ingestion-data/production/collections/houston-lst-night.json
@@ -84,5 +84,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Arto Marttinen](https://unsplash.com/photos/6xh7H5tWj9c) (Sunset over Tokyo)",
+            "href": "https://thumbnails.openveda.cloud/urban-heat.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-ndvi.json
+++ b/ingestion-data/production/collections/houston-ndvi.json
@@ -84,5 +84,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Arto Marttinen](https://unsplash.com/photos/6xh7H5tWj9c) (Sunset over Tokyo)",
+            "href": "https://thumbnails.openveda.cloud/urban-heat.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/houston-urbanization.json
+++ b/ingestion-data/production/collections/houston-urbanization.json
@@ -81,5 +81,14 @@
                 "processor"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Nick van den Berg](https://unsplash.com/photos/2vb-_3t6YCM) (Smog Located In City)",
+            "href": "https://thumbnails.openveda.cloud/smog-city.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/landfill-emit.json
+++ b/ingestion-data/production/collections/landfill-emit.json
@@ -75,5 +75,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Nick van den Berg](https://unsplash.com/photos/2vb-_3t6YCM) (Smog Located In City)",
+            "href": "https://thumbnails.openveda.cloud/smog-city.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-antarctic-glaciers-pine-island.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-antarctic-glaciers-pine-island.json
@@ -155,5 +155,14 @@
             "2022-12-24T14:52:13Z",
             "2023-01-25T14:52:12Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [EO Dashboard](https://eodashboard.org/explore?indicator=NLK&x=8286191.16928&y=3916735.01076&z=2.74483) (Screenshot of glacier in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-antarctic-glaciers-pine-island.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-antarctic-glaciers-thwaites.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-antarctic-glaciers-thwaites.json
@@ -162,5 +162,14 @@
             "2022-12-04T15:17:07Z",
             "2022-12-20T15:16:58Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [EO Dashboard](https://eodashboard.org/explore?indicator=NLK&x=8286191.16928&y=3916735.01076&z=2.74483) (Screenshot of glacier in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-antarctic-glaciers-thwaites.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-lakes-aral-sea.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-lakes-aral-sea.json
@@ -1534,5 +1534,14 @@
             "2023-06-20T06:39:55Z",
             "2023-06-20T06:40:19Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Planetary Computer](https://planetarycomputer.microsoft.com/explore?c=60.8520%2C45.4330&z=7.71&v=2&d=landsat-c2-l2&s=false%3A%3A100%3A%3Atrue&ae=0&sr=desc&m=Jun+%E2%80%93+Aug%2C+2022+%28low+cloud%29&r=Natural+color) (Screenshot of lake in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-lakes-aral-sea.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-lakes-lake-balaton.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-lakes-lake-balaton.json
@@ -286,5 +286,14 @@
             "2023-03-17T07:40:36Z",
             "2023-05-22T07:35:18Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [EO Dashboard](https://eodashboard.org/explore?indicator=NLK&x=8286191.16928&y=3916735.01076&z=2.74483) (Screenshot of lake in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-lakes-lake-balaton.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-lakes-lake-biwa.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-lakes-lake-biwa.json
@@ -172,5 +172,14 @@
             "2022-11-19T01:29:03Z",
             "2023-03-19T01:28:30Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Planetary Computer](https://planetarycomputer.microsoft.com/explore?c=136.1421%2C35.2565&z=10.14&v=2&d=landsat-c2-l2&s=false%3A%3A100%3A%3Atrue&ae=0&sr=desc&m=Most+recent+%28low+cloud%29&r=Natural+color) (Screenshot of lake in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-lakes-lake-biwa.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-lakes-tonle-sap.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-lakes-tonle-sap.json
@@ -430,5 +430,14 @@
             "2023-04-23T01:26:43Z",
             "2023-05-05T01:16:34Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Planetary Computer](https://planetarycomputer.microsoft.com/explore?c=104.1632%2C12.8505&z=9.43&v=2&d=landsat-c2-l2&s=false%3A%3A100%3A%3Atrue&ae=0&sr=desc&m=Most+recent+%28low+cloud%29&r=Natural+color) (Screenshot of lake in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-lakes-tonle-sap.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-c2l2-sr-lakes-vanern.json
+++ b/ingestion-data/production/collections/landsat-c2l2-sr-lakes-vanern.json
@@ -234,5 +234,14 @@
             "2023-05-24T10:12:48Z",
             "2023-06-09T10:12:43Z"
         ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [EO Dashboard](https://eodashboard.org/explore?indicator=NLK&x=8286191.16928&y=3916735.01076&z=2.74483) (Screenshot of lake in landsat natural color satellite image viewer)",
+            "href": "https://thumbnails.openveda.cloud/landsat-c2l2-sr-lakes-vanern.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
     }
 }

--- a/ingestion-data/production/collections/landsat-nighttime-thermal.json
+++ b/ingestion-data/production/collections/landsat-nighttime-thermal.json
@@ -50,5 +50,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Matthew Thayer/AP](https://www.sfchronicle.com/travel/article/hawaii-fire-maui-lahaina-18289213.php) (Wildfire erupting over Lahaina, HI, August 8, 2023)",
+            "href": "https://thumbnails.openveda.cloud/lahaina-fire-background.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-etsuppression.json
+++ b/ingestion-data/production/collections/lis-etsuppression.json
@@ -67,5 +67,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-evap.json
+++ b/ingestion-data/production/collections/lis-global-da-evap.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-gpp-trend.json
+++ b/ingestion-data/production/collections/lis-global-da-gpp-trend.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (TWS trend of anomalies from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/twsanomaly-globe.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-gpp.json
+++ b/ingestion-data/production/collections/lis-global-da-gpp.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-gws.json
+++ b/ingestion-data/production/collections/lis-global-da-gws.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-qs.json
+++ b/ingestion-data/production/collections/lis-global-da-qs.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-qsb.json
+++ b/ingestion-data/production/collections/lis-global-da-qsb.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-streamflow.json
+++ b/ingestion-data/production/collections/lis-global-da-streamflow.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-swe.json
+++ b/ingestion-data/production/collections/lis-global-da-swe.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-totalprecip.json
+++ b/ingestion-data/production/collections/lis-global-da-totalprecip.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-tws-trend.json
+++ b/ingestion-data/production/collections/lis-global-da-tws-trend.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (TWS trend of anomalies from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/twsanomaly-globe.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-global-da-tws.json
+++ b/ingestion-data/production/collections/lis-global-da-tws.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (One day of terrestrial water storage from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/global_tws_blackbg_v2.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-tvegsuppression.json
+++ b/ingestion-data/production/collections/lis-tvegsuppression.json
@@ -67,5 +67,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-tws-anomaly.json
+++ b/ingestion-data/production/collections/lis-tws-anomaly.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (TWS trend of anomalies from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/twsanomaly-globe.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-tws-nonstationarity-index.json
+++ b/ingestion-data/production/collections/lis-tws-nonstationarity-index.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (TWS trend of anomalies from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/twsanomaly-globe.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/lis-tws-trend.json
+++ b/ingestion-data/production/collections/lis-tws-trend.json
@@ -70,5 +70,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by NASA LIS (TWS trend of anomalies from LIS outputs)",
+            "href": "https://thumbnails.openveda.cloud/twsanomaly-globe.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/mtbs-burn-severity.json
+++ b/ingestion-data/production/collections/mtbs-burn-severity.json
@@ -76,5 +76,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mike Newbry](https://unsplash.com/photos/DwtX9mMHBJ0) (Hillside engulfed by wildfire)",
+            "href": "https://thumbnails.openveda.cloud/mtbs-burn-severity--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/nceo_africa_2017.json
+++ b/ingestion-data/production/collections/nceo_africa_2017.json
@@ -82,5 +82,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Olena Sergienko](https://unsplash.com/photos/0Ws_-v4Y_wY) (Green trees seen from above)",
+            "href": "https://thumbnails.openveda.cloud/nceo-africa--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/nightlights-hd-1band.json
+++ b/ingestion-data/production/collections/nightlights-hd-1band.json
@@ -77,5 +77,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA Earth Observatory](https://appliedsciences.nasa.gov/our-impact/news/satellite-observes-power-outages-new-orleans) (Nighttime lights for New Orleans, LA on August 31, 2021)",
+            "href": "https://thumbnails.openveda.cloud/nighttime-lights-ej--dataset-cover-neworleans.jpeg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/nightlights-hd-monthly.json
+++ b/ingestion-data/production/collections/nightlights-hd-monthly.json
@@ -77,5 +77,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA Earth Observatory](https://earthobservatory.nasa.gov/images/90008/night-light-maps-open-up-new-applications) (Satellite image of Earth at night)",
+            "href": "https://thumbnails.openveda.cloud/nighttime-lights--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/no2-monthly-diff.json
+++ b/ingestion-data/production/collections/no2-monthly-diff.json
@@ -78,5 +78,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mick Truyts](https://unsplash.com/photos/x6WQeNYJC1w) (Power plant shooting steam at the sky)",
+            "href": "https://thumbnails.openveda.cloud/no2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/no2-monthly.json
+++ b/ingestion-data/production/collections/no2-monthly.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Mick Truyts](https://unsplash.com/photos/x6WQeNYJC1w) (Power plant shooting steam at the sky)",
+            "href": "https://thumbnails.openveda.cloud/no2--dataset-cover.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/snow-projections-diff-245.json
+++ b/ingestion-data/production/collections/snow-projections-diff-245.json
@@ -87,5 +87,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Matterhorn glacier field)",
+            "href": "https://thumbnails.openveda.cloud/snow-projections-median.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/snow-projections-diff-585.json
+++ b/ingestion-data/production/collections/snow-projections-diff-585.json
@@ -87,5 +87,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Matterhorn glacier field)",
+            "href": "https://thumbnails.openveda.cloud/snow-projections-median.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/snow-projections-median-245.json
+++ b/ingestion-data/production/collections/snow-projections-median-245.json
@@ -86,5 +86,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Matterhorn glacier field)",
+            "href": "https://thumbnails.openveda.cloud/snow-projections-median.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/snow-projections-median-585.json
+++ b/ingestion-data/production/collections/snow-projections-median-585.json
@@ -86,5 +86,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by Justin Pflug (Photo of Matterhorn glacier field)",
+            "href": "https://thumbnails.openveda.cloud/snow-projections-median.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-household-nopop.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-household-nopop.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on household and disability score)",
+            "href": "https://thumbnails.openveda.cloud/svi-household--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-household.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-household.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on household and disability score)",
+            "href": "https://thumbnails.openveda.cloud/svi-household--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-housing-nopop.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-housing-nopop.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on housing type and transportation score)",
+            "href": "https://thumbnails.openveda.cloud/svi-housing--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-housing.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-housing.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on housing type and transportation score)",
+            "href": "https://thumbnails.openveda.cloud/svi-housing--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-minority-nopop.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-minority-nopop.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on minority status and language score)",
+            "href": "https://thumbnails.openveda.cloud/svi-minority--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-minority.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-minority.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on minority status and language score)",
+            "href": "https://thumbnails.openveda.cloud/svi-minority--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-overall-nopop.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-overall-nopop.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 overall Social Vulnerability Index (SVI)",
+            "href": "https://thumbnails.openveda.cloud/svi-overall--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-overall.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-overall.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 overall Social Vulnerability Index (SVI)",
+            "href": "https://thumbnails.openveda.cloud/svi-overall--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-socioeconomic-nopop.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-socioeconomic-nopop.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on socioeconomic data",
+            "href": "https://thumbnails.openveda.cloud/svi-socioeconomic--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/social-vulnerability-index-socioeconomic.json
+++ b/ingestion-data/production/collections/social-vulnerability-index-socioeconomic.json
@@ -79,5 +79,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [NASA](https://nasa.gov/) (2018 Social Vulnerability Index (SVI) based on socioeconomic data",
+            "href": "https://thumbnails.openveda.cloud/svi-socioeconomic--dataset-cover.png",
+            "type": "image/png",
+            "roles": ["thumbnail"]
+        }
+    }
 }

--- a/ingestion-data/production/collections/sport-lis-vsm0_100cm-percentile.json
+++ b/ingestion-data/production/collections/sport-lis-vsm0_100cm-percentile.json
@@ -71,5 +71,14 @@
                 "host"
             ]
         }
-    ]
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Clay Banks](https://unsplash.com/photos/EdscD_R28bM) (Dry Clay Wall with Cracks)",
+            "href": "https://thumbnails.openveda.cloud/soil-moisture-main.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
 }


### PR DESCRIPTION
## What
Adds thumbnail assets references to all production collections.

## How tested
I used the [transformation-scripts/collection-metadata-reconciliation.ipynb notebook](https://github.com/NASA-IMPACT/veda-data/blob/main/transformation-scripts/collection-metadata-reconciliation.ipynb)  to merge the thumbnail assets into the collections in [test.openveda.cloud](https://test.openveda.cloud) without overwriting existing item summaries.