### PR TITLE
feat(dataset): add greenville-nightlights-tornadoes-2024 dataset config

### DIFF
--- a/ingestion-data/production/dataset-config/greenville-nightlights-tornadoes-2024.json
+++ b/ingestion-data/production/dataset-config/greenville-nightlights-tornadoes-2024.json
@@ -16,8 +16,8 @@
       "enddate": "2024-05-08T23:59:59Z"
     },
     "sample_files": [
-      "s3://veda-data-store-staging/2024tornadoes_NightLights/nightlights_GreenvilleOH_cog_2024-05-07.tif",
-      "s3://veda-data-store-staging/2024tornadoes_NightLights/nightlights_GreenvilleOH_cog_2024-05-08.tif"
+      "s3://veda-data-store/greenville-nightlights-tornadoes-2024/nightlights_GreenvilleOH_cog_2024-05-07.tif",
+      "s3://veda-data-store/greenville-nightlights-tornadoes-2024/nightlights_GreenvilleOH_cog_2024-05-08.tif"
     ],
     "discovery_items": [
       {
@@ -25,8 +25,8 @@
         "cogify": false,
         "upload": false,
         "dry_run": false,
-        "prefix": "2024tornadoes_NightLights/",
-        "bucket": "veda-data-store-staging",
+        "prefix": "greenville-nightlights-tornadoes-2024/",
+        "bucket": "veda-data-store",
         "filename_regex": ".*Greenville.*.tif$",
         "use_multithreading": false
       }

--- a/ingestion-data/production/transfer-config/greenville-nightlights-tornadoes-2024.json
+++ b/ingestion-data/production/transfer-config/greenville-nightlights-tornadoes-2024.json
@@ -1,0 +1,7 @@
+{
+    "origin_bucket": "veda-data-store-staging",
+    "origin_prefix": "2024tornadoes_NightLights/",
+    "target_bucket": "veda-data-store",
+    "collection": "greenville-nightlights-tornadoes-2024",
+    "filename_regex": ".*Greenville.*.tif$"
+}

--- a/ingestion-data/staging/dataset-config/greenville-nightlights-tornadoes-2024.json
+++ b/ingestion-data/staging/dataset-config/greenville-nightlights-tornadoes-2024.json
@@ -1,0 +1,83 @@
+{
+    "collection": "greenville-nightlights-tornadoes-2024",
+    "title": "Black Marble Night Lights– 2024 Spring Tornadoes Damage (Greenville, OH)",
+    "description": "NASA Black Marble Night Lights shows the path of a tornado through Greenville, Ohio on May 7th, 2024, revealing where power loss occurred due to this tornado strike on the city.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+    "xmin": -125,
+    "ymin": 24,
+    "xmax": -65,
+    "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-07T00:00:00Z",
+      "enddate": "2024-05-08T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store-staging/2024tornadoes_NightLights/nightlights_GreenvilleOH_cog_2024-05-07.tif",
+      "s3://veda-data-store-staging/2024tornadoes_NightLights/nightlights_GreenvilleOH_cog_2024-05-08.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "2024tornadoes_NightLights/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": ".*Greenville.*.tif$",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [ {AUTHOR OR ORGANIZATION NAME mdx: media.author} ]( {LINK TO AUTHOR mdx: media.url} ) ( {ALT TEXT MDX media.alt} )",
+            "href": "https://thumbnails.openveda.cloud/{THUMBNAIL_FILENAME.EXT}",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    },
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "{nearest CHANGE ME}",
+            "bidx": [1],
+            "colormap_name": "{CHANGE ME}",
+            "nodata": "{CHANGE ME}",
+            "assets": [
+                "{cog_default CHANGE ME}"
+            ],
+            "rescale": ["CHANGE ME MIN", "CHANGE ME MAX"],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    }
+  }


### PR DESCRIPTION
## What
Add stac collection and ingestion config for `greenville-nightlights-tornadoes-2024`

## Parent issue
https://github.com/NASA-IMPACT/veda-data/issues/187

## Downstream veda-config PR
https://github.com/NASA-IMPACT/veda-config/pull/420

## Checklist
- [x] align title and description with veda-config
- [x] staging config completed and verified
- [x] published to staging
- [x] transfer config and production metadata updated
- [x] published to production