### PR TITLE
feat(dataset): add ps-tornadoes-2024-difference dataset config

### DIFF
--- a/ingestion-data/production/dataset-config/ps-tornadoes-2024-difference.json
+++ b/ingestion-data/production/dataset-config/ps-tornadoes-2024-difference.json
@@ -1,0 +1,80 @@
+{
+    "collection": "ps-tornadoes-2024-difference",
+    "title": "Planet TrueColor Satellite Imagery Difference (Greenfield IA Tornado Damage)",
+    "description": "Commercial SmallSat Planet Satellite Imagery difference of tornado damage at Greenfield, Iowa in the spring 2024 tornado season.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+      "xmin": -125,
+      "ymin": 24,
+      "xmax": -65,
+      "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-21T00:00:00Z",
+      "enddate": "2024-05-21T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store/ps-tornadoes-2024-difference/Planet_Greenfield_Difference_FCC_cog_2024-05-21.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "ps-tornadoes-2024-difference/",
+        "bucket": "veda-data-store",
+        "filename_regex": ".*Planet_Greenfield_Difference_FCC_cog_2024-05-21.tif",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "description": "Photo by [Jonny Glessner](https://x.com/JonnyGlessner/status/1768424574855610777/photo/4) (Wedge tornado passing southeast of Wapakoneta, Ohio on March 14, 2024)",
+          "href": "https://thumbnails.openveda.cloud/tornado-2024-cover.png",
+          "type": "image/jpeg",
+          "roles": ["thumbnail"]
+      }
+    },
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "bilinear",
+            "bidx": [4,3,2],
+            "assets": [
+                "cog_default"
+            ],
+            "rescale": [[0,255]],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    }
+  }

--- a/ingestion-data/production/transfer-config/ps-tornadoes-2024-difference.json
+++ b/ingestion-data/production/transfer-config/ps-tornadoes-2024-difference.json
@@ -1,0 +1,7 @@
+{
+    "origin_bucket": "veda-data-store-staging",
+    "origin_prefix": "2024tornadoes_Planet/",
+    "target_bucket": "veda-data-store",
+    "collection": "ps-tornadoes-2024-difference",
+    "filename_regex": ".*Planet_Greenfield_Difference_FCC_cog_2024-05-21.tif"
+}

--- a/ingestion-data/staging/dataset-config/ps-tornadoes-2024-difference.json
+++ b/ingestion-data/staging/dataset-config/ps-tornadoes-2024-difference.json
@@ -1,0 +1,82 @@
+{
+    "collection": "ps-tornadoes-2024-difference",
+    "title": "Planet Imagery – 2024 Spring Tornadoes Damage False Color Difference",
+    "description": "Commercial SmallSat PlanetScope Satellite Visible Imagery three band difference over Greenfield, Iowa showing changes before vs. after the tornado strike on the town.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+      "xmin": -125,
+      "ymin": 24,
+      "xmax": -65,
+      "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-21T00:00:00Z",
+      "enddate": "2024-05-21T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store-staging/2024tornadoes_Planet/Planet_Greenfield_Difference_FCC_cog_2024-05-21.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "2024tornadoes_Planet/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": ".*Planet_Greenfield_Difference_FCC_cog_2024-05-21.tif",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [ {AUTHOR OR ORGANIZATION NAME mdx: media.author} ]( {LINK TO AUTHOR mdx: media.url} ) ( {ALT TEXT MDX media.alt} )",
+            "href": "https://thumbnails.openveda.cloud/{THUMBNAIL_FILENAME.EXT}",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    },
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "{nearest CHANGE ME}",
+            "bidx": [1],
+            "colormap_name": "{CHANGE ME}",
+            "nodata": "{CHANGE ME}",
+            "assets": [
+                "{cog_default CHANGE ME}"
+            ],
+            "rescale": ["CHANGE ME MIN", "CHANGE ME MAX"],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    }
+  }

--- a/ingestion-data/staging/dataset-config/ps-tornadoes-2024-difference.json
+++ b/ingestion-data/staging/dataset-config/ps-tornadoes-2024-difference.json
@@ -1,7 +1,7 @@
 {
     "collection": "ps-tornadoes-2024-difference",
-    "title": "Planet Imagery – 2024 Spring Tornadoes Damage False Color Difference",
-    "description": "Commercial SmallSat PlanetScope Satellite Visible Imagery three band difference over Greenfield, Iowa showing changes before vs. after the tornado strike on the town.",
+    "title": "Planet TrueColor Satellite Imagery Difference (Greenfield IA Tornado Damage)",
+    "description": "Commercial SmallSat Planet Satellite Imagery difference of tornado damage at Greenfield, Iowa in the spring 2024 tornado season.",
     "license": "CC0-1.0",
     "is_periodic": true,
     "time_density": "day",
@@ -43,12 +43,12 @@
     ],
     "assets": {
         "thumbnail": {
-            "title": "Thumbnail",
-            "description": "Photo by [ {AUTHOR OR ORGANIZATION NAME mdx: media.author} ]( {LINK TO AUTHOR mdx: media.url} ) ( {ALT TEXT MDX media.alt} )",
-            "href": "https://thumbnails.openveda.cloud/{THUMBNAIL_FILENAME.EXT}",
-            "type": "image/jpeg",
-            "roles": ["thumbnail"]
-        }
+          "title": "Thumbnail",
+          "description": "Photo by [Jonny Glessner](https://x.com/JonnyGlessner/status/1768424574855610777/photo/4) (Wedge tornado passing southeast of Wapakoneta, Ohio on March 14, 2024)",
+          "href": "https://thumbnails.openveda.cloud/tornado-2024-cover.png",
+          "type": "image/jpeg",
+          "roles": ["thumbnail"]
+      }
     },
     "stac_version": "1.0.0",
     "stac_extensions": [
@@ -68,14 +68,12 @@
     },
     "renders": {
         "dashboard": {
-            "resampling": "{nearest CHANGE ME}",
-            "bidx": [1],
-            "colormap_name": "{CHANGE ME}",
-            "nodata": "{CHANGE ME}",
+            "resampling": "bilinear",
+            "bidx": [4,3,2],
             "assets": [
-                "{cog_default CHANGE ME}"
+                "cog_default"
             ],
-            "rescale": ["CHANGE ME MIN", "CHANGE ME MAX"],
+            "rescale": [[0,255]],
             "title": "VEDA Dashboard Render Parameters"
         }
     }


### PR DESCRIPTION
## What
Add stac collection and ingestion config for `ps-tornadoes-2024-difference`

## Parent issue
https://github.com/NASA-IMPACT/veda-data/issues/187

## Downstream veda-config PR
https://github.com/NASA-IMPACT/veda-config/pull/420

## Checklist
- [x] align title and description with veda-config
- [x] staging config completed and verified
- [x] published to staging
- [x] transfer config and production metadata updated
- [x] published to production