### PR TITLE
feat(dataset): add ps-greenfield-post-tornadoes-2024 dataset config

### DIFF
--- a/ingestion-data/staging/dataset-config/ps-greenfield-post-tornadoes-2024.json
+++ b/ingestion-data/staging/dataset-config/ps-greenfield-post-tornadoes-2024.json
@@ -1,0 +1,83 @@
+{
+    "collection": "ps-greenfield-post-tornadoes-2024",
+    "title": "Planet Imagery – 2024 Spring Tornadoes Damage (Greenfield IA Post)",
+  "description": "Commercial SmallSat PlanetScope Satellite Visible Imagery of select locations that experienced tornado damage during the spring of 2024 in the United States. The location in this collection is Greenfield, Iowa after the tornado strike.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+    "xmin": -125,
+    "ymin": 24,
+    "xmax": -65,
+    "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-22T00:00:00Z",
+      "enddate": "2024-05-22T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store-staging/2024tornadoes_Planet/Planet_Greenfield_After_cog_2024-05-22.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "2024tornadoes_Planet/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": ".*Planet_.*_cog_.*05-22.tif$",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [ {AUTHOR OR ORGANIZATION NAME mdx: media.author} ]( {LINK TO AUTHOR mdx: media.url} ) ( {ALT TEXT MDX media.alt} )",
+            "href": "https://thumbnails.openveda.cloud/{THUMBNAIL_FILENAME.EXT}",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    },
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "{nearest CHANGE ME}",
+            "bidx": [1],
+            "colormap_name": "{CHANGE ME}",
+            "nodata": "{CHANGE ME}",
+            "assets": [
+                "{cog_default CHANGE ME}"
+            ],
+            "rescale": ["CHANGE ME MIN", "CHANGE ME MAX"],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    }
+  }
+  


### PR DESCRIPTION
## What
Add stac collection and ingestion config for `ps-greenfield-post-tornadoes-202`

## Parent issue
https://github.com/NASA-IMPACT/veda-data/issues/187

## Downstream veda-config PR
https://github.com/NASA-IMPACT/veda-config/pull/420

## Checklist
- [ ] align title and description with veda-config
- [ ] staging config completed and verified
- [ ] published to staging
- [ ] transfer config and production metadata updated
- [ ] published to production