### PR TITLE
feat(dataset): add ps-portage-tornadoes-2024 dataset config

### DIFF
--- a/ingestion-data/production/dataset-config/ps-portage-tornadoes-2024.json
+++ b/ingestion-data/production/dataset-config/ps-portage-tornadoes-2024.json
@@ -1,0 +1,80 @@
+{
+    "collection": "ps-portage-tornadoes-2024",
+    "title": "Planet TrueColor Satellite Imagery (Portage MI Tornado Damage)",
+    "description": "Commercial SmallSat PlanetScope Satellite Visible Imagery of select locations that experienced tornado damage during the spring of 2024 in the United States. The location in this collection is Portage, Michigan.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+    "xmin": -125,
+    "ymin": 24,
+    "xmax": -65,
+    "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-13T00:00:00Z",
+      "enddate": "2024-05-13T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store/ps-portage-tornadoes-2024/Planet_Portage_After_cog_2024-05-13.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "ps-portage-tornadoes-2024/",
+        "bucket": "veda-data-store",
+        "filename_regex": ".*Planet_.*_cog_.*05-13.tif$",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "bilinear",
+            "bidx": [1,2,3],
+            "assets": [
+                "cog_default"
+            ],
+            "rescale": [[0, 255]],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jonny Glessner](https://x.com/JonnyGlessner/status/1768424574855610777/photo/4) (Wedge tornado passing southeast of Wapakoneta, Ohio on March 14, 2024)",
+            "href": "https://thumbnails.openveda.cloud/tornado-2024-cover.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
+  }

--- a/ingestion-data/production/transfer-config/ps-portage-tornadoes-2024.json
+++ b/ingestion-data/production/transfer-config/ps-portage-tornadoes-2024.json
@@ -1,0 +1,7 @@
+{
+    "origin_bucket": "veda-data-store-staging",
+    "origin_prefix": "2024tornadoes_Planet/",
+    "target_bucket": "veda-data-store",
+    "collection": "ps-portage-tornadoes-2024",
+    "filename_regex": ".*Planet_.*_cog_.*05-13.tif$"
+}

--- a/ingestion-data/staging/dataset-config/ps-portage-tornadoes-2024.json
+++ b/ingestion-data/staging/dataset-config/ps-portage-tornadoes-2024.json
@@ -1,0 +1,80 @@
+{
+    "collection": "ps-portage-tornadoes-2024",
+    "title": "Planet TrueColor Satellite Imagery (Portage MI Tornado Damage)",
+    "description": "Commercial SmallSat PlanetScope Satellite Visible Imagery of select locations that experienced tornado damage during the spring of 2024 in the United States. The location in this collection is Portage, Michigan.",
+    "license": "CC0-1.0",
+    "is_periodic": true,
+    "time_density": "day",
+    "spatial_extent": {
+    "xmin": -125,
+    "ymin": 24,
+    "xmax": -65,
+    "ymax": 50
+    },
+    "temporal_extent": {
+      "startdate": "2024-05-13T00:00:00Z",
+      "enddate": "2024-05-13T23:59:59Z"
+    },
+    "sample_files": [
+      "s3://veda-data-store-staging/2024tornadoes_Planet/Planet_Portage_After_cog_2024-05-13.tif"
+    ],
+    "discovery_items": [
+      {
+        "discovery": "s3",
+        "cogify": false,
+        "upload": false,
+        "dry_run": false,
+        "prefix": "2024tornadoes_Planet/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": ".*Planet_.*_cog_.*05-13.tif$",
+        "use_multithreading": false
+      }
+    ],
+    "data_type": "cog",
+    "datetime_range": "day",
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": [
+          "host"
+        ],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    },
+    "renders": {
+        "dashboard": {
+            "resampling": "bilinear",
+            "bidx": [1,2,3],
+            "assets": [
+                "cog_default"
+            ],
+            "rescale": [[0, 255]],
+            "title": "VEDA Dashboard Render Parameters"
+        }
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "description": "Photo by [Jonny Glessner](https://x.com/JonnyGlessner/status/1768424574855610777/photo/4) (Wedge tornado passing southeast of Wapakoneta, Ohio on March 14, 2024)",
+            "href": "https://thumbnails.openveda.cloud/tornado-2024-cover.png",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"]
+        }
+    }
+  }


### PR DESCRIPTION
## What
Add stac collection and ingestion config for `ps-portage-tornadoes-2024`

## Parent issue
https://github.com/NASA-IMPACT/veda-data/issues/187

## Downstream veda-config PR
https://github.com/NASA-IMPACT/veda-config/pull/420

## Checklist
- [x] align title and description with veda-config
- [x] staging config completed and verified
- [x] published to staging
- [x] transfer config and production metadata updated
- [x] published to production