### PR TITLE
feat: change promotion checker to run on PR merge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -424,26 +424,3 @@ jobs:
           gh api -X PATCH -H "Authorization: token $GITHUB_TOKEN" /repos/${{ github.repository }}/issues/comments/$COMMENT_ID -f body="$UPDATED_BODY"
 
           echo "Updated Comment Body: $UPDATED_BODY"
-
-  trigger-promotion-checker:
-    runs-on: ubuntu-latest
-    environment: staging
-    needs: create-mdx-files-and-open-pr
-    permissions:
-      actions: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check if WORKFLOW_TRIGGER_TOKEN is set
-        run: |
-          echo "WORKFLOW_TRIGGER_TOKEN is set: ${{ secrets.WORKFLOW_TRIGGER_TOKEN != ''}}"
-
-      - name: Trigger Promotion checker workflow
-        run: |
-          gh workflow list
-          gh workflow run promotion-checker.yml -f pr_number=${{ github.event.pull_request.number }} -f trigger_token=${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_TRIGGER_TOKEN : ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -11,10 +11,6 @@ on:
         description: "Security token for internal workflow calls"
         required: true
         type: string
-  workflow_run:
-    workflows: ["Promotion checker"]
-    types:
-      - completed
 
 jobs:
   validate-trigger-token:

--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -1,36 +1,22 @@
-name: Promotion checker
+name: Post-Approval and Post-Merge Collection Promotion Checker
 
 on:
-  workflow_dispatch:
-    inputs:
-        pr_number:
-            description: "Pull Request Number"
-            required: true
-            type: string
-        trigger_token:
-            description: "Security token for internal workflow calls"
-            required: true
-            type: string
+  pull_request:
+    types:
+      - closed
 
 permissions:
     actions: write
     contents: read
 
 jobs:
-  validate-trigger-token:
+  check-conditions:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
-      - name: Verify token
-        run: |
-          if [ "${{ github.event.inputs.trigger_token }}" != "${{ secrets.WORKFLOW_TRIGGER_TOKEN }}" ]; then
-            echo "Invalid trigger token. Request unauthorized. Exiting..."
-            exit 1
-          fi
-        env:
-          WORKFLOW_TRIGGER_TOKEN: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
-  check-pr-approval:
-    runs-on: ubuntu-latest
-    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Print PR number
         run: |
           echo "Processing PR \#${{ github.event.inputs.pr_number }}"
@@ -50,10 +36,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if pr.yml succeeded
+        id: check_pr_workflow
+        run: |
+          WORKFLOW_STATUS=$(gh run list --repo ${{ github.repository }} --branch ${{ github.event.pull_request.head.ref }} --workflow "pr.yml" --json status --jq '[0].status')
+          echo "Previous workflow (pr.yml) status: $WORKFLOW_STATUS"
+          if [ "$WORKFLOW_STATUS" != "completed" ]; then
+            echo "Previous workflow (pr.yml) did not complete successfully. Exiting..."
+            exit 1
+          fi
+
       - name: Trigger Promotion workflow
-        if: env.APPROVED == 'true'
         run: |
           gh workflow list
-          gh workflow run promote.yml -f trigger_token=${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
+          gh workflow run promote.yml --repo ${{ github.repository }} -f trigger_token=${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: Print PR number
         run: |
           echo "Processing PR \#${{ github.event.inputs.pr_number }}"
@@ -45,6 +42,13 @@ jobs:
             echo "Previous workflow (pr.yml) did not complete successfully. Exiting..."
             exit 1
           fi
+
+  trigger-promotion-workflow:
+    runs-on: ubuntu-latest
+    needs: check-conditions
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
       - name: Trigger Promotion workflow
         run: |


### PR DESCRIPTION
### Changes
- Updates pr.yml to no longer trigger the intermediate promotion checker workflow
- Updates the promotion-checker workflow to check that the PR was merged and approved and checks that `pr.yml` was run and completed successfully before triggering the promote.yml workflow
- Updates promote.yml workflow to be triggered only on workflow dispatch
- Updates promotion checker to pass PR number to promote workflow so we can identify which PR is associated with the promotion run. 