### PR TITLE
fix: add github token env var

### DIFF
--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -42,6 +42,8 @@ jobs:
             echo "Previous workflow (pr.yml) did not complete successfully. Exiting..."
             exit 1
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   trigger-promotion-workflow:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Addresses https://github.com/NASA-IMPACT/veda-data/actions/runs/13147286952/job/36688076780
```
Run WORKFLOW_STATUS=$(gh run list --repo NASA-IMPACT/veda-data --branch feat/ida-ndwi-difference-TEST-PROMOTE-2 --workflow "pr.yml" --json status --jq '.[0].status // "not found"')
  WORKFLOW_STATUS=$(gh run list --repo NASA-IMPACT/veda-data --branch feat/ida-ndwi-difference-TEST-PROMOTE-[2](https://github.com/NASA-IMPACT/veda-data/actions/runs/13147286952/job/36688076780#step:4:2) --workflow "pr.yml" --json status --jq '.[0].status // "not found"')
  echo "Previous workflow (pr.yml) status: $WORKFLOW_STATUS"
  if [ "$WORKFLOW_STATUS" != "completed" ]; then
    echo "Previous workflow (pr.yml) did not complete successfully. Exiting..."
    exit 1
  fi
  shell: /usr/bin/bash -e {0}
  env:
    PR_NUMBER: 2[4](https://github.com/NASA-IMPACT/veda-data/actions/runs/13147286952/job/36688076780#step:4:4)2
    APPROVED: true
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```