### PR TITLE
fix: move read run id to promotion workflow trigger job

### DIFF
--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -44,6 +44,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  trigger-promotion-workflow:
+    runs-on: ubuntu-latest
+    needs: check-conditions
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Get Workflow Run ID Artifact
         run: |
           gh run download \
@@ -57,16 +64,9 @@ jobs:
         id: read-run-id
         run: |
           cat run_id.txt
-          echo "RUN_ID=$(cat run_id.txt)" >> $GITHUB_ENV
           RUN_ID=$(cat run_id.txt)
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
           echo $RUN_ID
-
-  trigger-promotion-workflow:
-    runs-on: ubuntu-latest
-    needs: check-conditions
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
 
       - name: Trigger Promotion workflow
         run: |


### PR DESCRIPTION
Environment variables set using `echo ... >> $GITHUB_ENV` are only available within the same job.