### PR TITLE
fix(docs): update links after veda docs site re-org

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 24.3.0
     hooks:
       - id: black
       - id: black-jupyter

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ To add data to VEDA you will:
 
 ### Step 1: Stage your files
 
-Upload files to the staging bucket `s3://veda-data-store-staging` (which you can do with a VEDA JupyterHub account--request access [here](https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/#veda-sponsored-jupyterhub-service)) or a self-hosted bucket in s3 has shared read access to VEDA service. [See docs.openveda.cloud for additional details on preparing files.](https://docs.openveda.cloud/instance-management/adding-content/dataset-ingestion/file-preparation.html)
+Upload files to the staging bucket `s3://veda-data-store-staging` (which you can do with a VEDA JupyterHub account--request access [here](https://docs.openveda.cloud/user-guide/scientific-computing/getting-access.html)) or a self-hosted bucket in s3 has shared read access to VEDA service. [See docs.openveda.cloud for additional details on preparing files.](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/file-preparation.html)
 
 ### Step 2: Generate STAC metadata in the staging catalog
 
-Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file using the veda-ingest-ui and submit it to the `/workflows/dataset/publish` endpoint to generate STAC Collection metadata and generate Item records for the files you have uploaded in Step 1.
+Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file using the veda-ingest-ui to generate STAC Collection metadata and generate Item records for the files you have uploaded in Step 1.
 
 * Use the veda-ingest-ui form to generate a dataset config and open a veda-data PR
 
@@ -32,13 +32,13 @@ Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/
 
 * When a veda-data PR is opened, a github action will automatically (1) POST the config to airflow and stage the collection and items in the staging catalog instance and (2) open a veda-config dashboard preview for the dataset.
 
-> See detailed steps for the [dataset submission process](https://docs.openveda.cloud/instance-management/adding-content/dataset-ingestion/) in the contribuing section of [veda-docs](https://nasa-impact.github.io/veda-docs) where you can also find this full ingestion workflow example [geoglam ingest notebook](https://docs.openveda.cloud/instance-management/adding-content/dataset-ingestion/example-template/example-geoglam-ingest.html)
+> See detailed steps for the [dataset submission process](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/) in the Content Curation section of the User Guide in [veda-docs](https://nasa-impact.github.io/veda-docs) where you can also find this full ingestion workflow example [geoglam ingest notebook](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/example-template/example-geoglam-ingest.html)
 
 ### Step 3: Acceptance testing
 
 Perform acceptance testing appropriate for your data. This should include reviewing the [staging.openveda.cloud STAC browser](https://staging.openveda.cloud) and reviewing the corresponding veda-config PR dashboard preview.
 
-> See [veda-docs/instance-management/adding-content/dashboard-configuration](https://docs.openveda.cloud/instance-management/adding-content/dashboard-configuration/dataset-configuration.html) for more information about configuring a dashboard preview).
+> See the [Content Curation/Dashboard Configuration](https://docs.openveda.cloud/user-guide/content-curation/dashboard-configuration/) section of the User Guide in docs.openveda.cloud for more information about configuring a dashboard preview.
 
 ### Step 4: Promote to production
 
@@ -48,7 +48,9 @@ After acceptance testing, request approval--when your PR is merged, the dataset 
 
 ### Step 5 [Optional]: Share your data
 
-Share your data in the [VEDA Dashboard](https://www.earthdata.nasa.gov/dashboard/) by submitting a PR to [veda-config](https://github.com/NASA-IMPACT/veda-config) ([see veda-docs/contributing/dashboard-configuration](https://nasa-impact.github.io/veda-docs/contributing/dashboard-configuration/dataset-configuration.html)) and add jupyterhub hosted usage examples to [veda-docs/contributing/docs-and-notebooks](https://nasa-impact.github.io/veda-docs/contributing/docs-and-notebooks.html)
+* Share your data in the VEDA Dashboard [User Guide > Content Curation > Dashboard Configuration](https://docs.openveda.cloud/user-guide/content-curation/dashboard-configuration/)
+
+* Add jupyterhub hosted usage examples to docs.openveda.cloud [User Guide > Content Curation > Usage Example Notebook Submission](https://docs.openveda.cloud/user-guide/content-curation/docs-and-notebooks.html)
 
 ## Project ingestion data structure
 
@@ -59,7 +61,7 @@ Various ingestion workflows are supported and documented below but only the conf
 
 ### `<stage>/collections/`
 
-The `ingestion-data/collections/` directory holds json files representing the data for VEDA collection metadata (STAC). STAC Collection metadata can be generated from an id, title, description using Pystac. See this [veda-docs/contributing notebook example](https://nasa-impact.github.io/veda-docs/notebooks/veda-operations/stac-collection-creation.html) to get started.
+The `ingestion-data/collections/` directory holds json files representing the data for VEDA collection metadata (STAC). STAC Collection metadata can be generated from an id, title, description using Pystac. See [User Guide > Content Curation > Dataset Ingestion > STAC Collection Creation](https://docs.openveda.cloud/user-guide/notebooks/veda-operations/stac-collection-creation.html) to get started.
 
 Should follow the following format:
 
@@ -174,7 +176,7 @@ Should follow the following format:
 
 ### `<stage>/dataset-config/`
 
-The `ingestion-data/dataset-config/` directory holds json files that can be used with the `dataset/publish` workflows endpoint, combining both collection metadata and discovery items. For an example of this ingestion workflow, see this [geoglam ingest notebook in nasa-impact.github.io/veda-docs/contributing/dataset-ingeston](https://nasa-impact.github.io/veda-docs/contributing/dataset-ingestion/example-template/example-geoglam-ingest.html).
+The `ingestion-data/dataset-config/` directory holds json files that can be used with the `dataset/publish` workflows endpoint, combining both collection metadata and discovery items. For an example of this ingestion workflow, see this [geoglam ingest notebook in the Content Curation section of the VEDA User Guide](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/example-template/example-geoglam-ingest.html).
 
 <details>
   <summary><b>/dataset-config/collection_id.json</b></summary>

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Should follow the following format:
 
 ### `<stage>/dataset-config/`
 
-The `ingestion-data/dataset-config/` directory holds json files that can be used with the `dataset/publish` workflows endpoint, combining both collection metadata and discovery items. For an example of this ingestion workflow, see this [geoglam ingest notebook in the Content Curation section of the VEDA User Guide](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/example-template/example-geoglam-ingest.html).
+The `ingestion-data/dataset-config/` directory holds JSON files that can be used with the `dataset/publish` workflows endpoint, combining both collection metadata and discovery items. For an example of this ingestion workflow, see this [geoglam ingest notebook in the Content Curation section of the VEDA User Guide](https://docs.openveda.cloud/user-guide/content-curation/dataset-ingestion/example-template/example-geoglam-ingest.html).
 
 <details>
   <summary><b>/dataset-config/collection_id.json</b></summary>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After acceptance testing, request approval--when your PR is merged, the dataset 
 
 * Share your data in the VEDA Dashboard [User Guide > Content Curation > Dashboard Configuration](https://docs.openveda.cloud/user-guide/content-curation/dashboard-configuration/)
 
-* Add jupyterhub hosted usage examples to docs.openveda.cloud [User Guide > Content Curation > Usage Example Notebook Submission](https://docs.openveda.cloud/user-guide/content-curation/docs-and-notebooks.html)
+* Add JupyterHub hosted usage examples to docs.openveda.cloud [User Guide > Content Curation > Usage Example Notebook Submission](https://docs.openveda.cloud/user-guide/content-curation/docs-and-notebooks.html)
 
 ## Project ingestion data structure
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Upload files to the staging bucket `s3://veda-data-store-staging` (which you can
 
 ### Step 2: Generate STAC metadata in the staging catalog
 
-Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file using the veda-ingest-ui to generate STAC Collection metadata and generate Item records for the files you have staged in Step 1.
+Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file with the [ingest.openveda.cloud](https://ingest.openveda.cloud) form to generate STAC Collection metadata and generate Item records for the files you have staged in Step 1.
 
-* Use the veda-ingest-ui form to generate a dataset config and open a veda-data PR
+* Use the [ingest.openveda.cloud](https://ingest.openveda.cloud) form to generate a dataset config and open a veda-data PR
 
 * OR manually generate a dataset-config JSON and open a veda-data PR
 
@@ -149,7 +149,7 @@ Should follow the following format:
 
 ### `<stage>/discovery-items/`
 
-The `ingestion-data/discovery-items/` directory holds json files representing the inputs for initiating the discovery, ingest and publication workflows.
+The `ingestion-data/discovery-items/` directory holds JSON files representing the inputs for initiating the discovery, ingest and publication workflows.
 Can either be a single input event or a list of input events.
 
 Should follow the following format:
@@ -244,7 +244,7 @@ Should follow the following format:
 
 ### `production/promotion-config`
 
-This directory contains the configuration needed to execute a stand-alone airflow DAG that transfers assets to production and generates production metadata. The promotion-config json uses the same schema and values from the [staging/dataset-config JSON](#stagedataset-config) with an additional `transfer` field which should be set to true when S3 objects need to be transferred from a staging location to the production data store. The veda data promotion pipeline copies data from a specified staging bucket and prefix to a permanent location in `s3://veda-data-store` using the collection_id as a prefix and publishes STAC metadata to the produciton catalog.
+This directory contains the configuration needed to execute a stand-alone airflow DAG that transfers assets to production and generates production metadata. The promotion-config JSON uses the same schema and values from the [staging/dataset-config JSON](#stagedataset-config) with an additional `transfer` field which should be set to true when S3 objects need to be transferred from a staging location to the production data store. The veda data promotion pipeline copies data from a specified staging bucket and prefix to a permanent location in `s3://veda-data-store` using the collection_id as a prefix and publishes STAC metadata to the produciton catalog.
 
 <details>
   <summary><b>production/promotion-config/collection_id.json</b></summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Upload files to the staging bucket `s3://veda-data-store-staging` (which you can
 
 ### Step 2: Generate STAC metadata in the staging catalog
 
-Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file using the veda-ingest-ui to generate STAC Collection metadata and generate Item records for the files you have uploaded in Step 1.
+Metadata must first be added to the Staging Catalog [staging.openveda.cloud/api/stac](https://staging.openveda.cloud/api/stac). You will need to create a dataset config file using the veda-ingest-ui to generate STAC Collection metadata and generate Item records for the files you have staged in Step 1.
 
 * Use the veda-ingest-ui form to generate a dataset config and open a veda-data PR
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Various ingestion workflows are supported and documented below but only the conf
 
 ### `<stage>/collections/`
 
-The `ingestion-data/collections/` directory holds json files representing the data for VEDA collection metadata (STAC). STAC Collection metadata can be generated from an id, title, description using Pystac. See [User Guide > Content Curation > Dataset Ingestion > STAC Collection Creation](https://docs.openveda.cloud/user-guide/notebooks/veda-operations/stac-collection-creation.html) to get started.
+The `ingestion-data/collections/` directory holds JSON files representing the data for VEDA collection metadata (STAC). STAC Collection metadata can be generated from an `id`, `title`,  and `description` using PySTAC. See [User Guide > Content Curation > Dataset Ingestion > STAC Collection Creation](https://docs.openveda.cloud/user-guide/notebooks/veda-operations/stac-collection-creation.html) to get started.
 
 Should follow the following format:
 

--- a/transformation-scripts/collection-and-item-ingest.ipynb
+++ b/transformation-scripts/collection-and-item-ingest.ipynb
@@ -130,9 +130,9 @@
     "client = CognitoClient(\n",
     "    client_id=test_client_id if testing_mode else mcp_prod_client_id,\n",
     "    user_pool_id=test_user_pool_id if testing_mode else mcp_prod_user_pool_id,\n",
-    "    identity_pool_id=test_identity_pool_id\n",
-    "    if testing_mode\n",
-    "    else mcp_prod_identity_pool_id,\n",
+    "    identity_pool_id=(\n",
+    "        test_identity_pool_id if testing_mode else mcp_prod_identity_pool_id\n",
+    "    ),\n",
     ")\n",
     "_ = client.login()"
    ]


### PR DESCRIPTION
Update links to docs.openveda.cloud after it was [re-organized](https://github.com/NASA-IMPACT/veda-docs/pull/203)