### PR TITLE
feat: PR/promotion checker should not be invoked for non-data changes

### DIFF
--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - closed
+    paths:
+      - ingestion-data/staging/dataset-config/*.json
 
 permissions:
     actions: write


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-data/issues/330

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths

This will limit the workflow to running if the PR is not a dataset-config *.json file change. `path` creates a condition where at least one path matches a pattern in the paths filter, the workflow runs.