### PR TITLE
fix: use commit hash in actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
       comment_id: ${{ steps.init-comment.outputs.COMMENT_ID }}
       has_new_files_to_promote: ${{ steps.changed-files.outputs.all_changed_files_count != 0 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Initializes the PR comment
       # Edits existing or creates new comment
@@ -69,7 +69,7 @@ jobs:
       # The files are outputted to GITHUB_OUTPUT, which can be used in subsequent steps
       - name: Get newly added and changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: ingestion-data/staging/dataset-config/**.json
 
@@ -160,10 +160,10 @@ jobs:
           gh api -X PATCH -H "Authorization: token $GITHUB_TOKEN" /repos/${{ github.repository }}/issues/comments/$COMMENT_ID -f body="$UPDATED_BODY"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.9'
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-pip-${{ hashFiles('requirements.txt') }}
@@ -204,7 +204,7 @@ jobs:
     needs: publish-new-datasets
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Use output from publish-new-datasets
         run: |
@@ -244,7 +244,7 @@ jobs:
         run: ls -lah /tmp/upload-artifacts
 
       - name: Upload published collections files as directory artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         env:
           ARTIFACT_RETENTION_DAYS: ${{ vars.ARTIFACT_RETENTION_DAYS }}
         with:
@@ -258,7 +258,7 @@ jobs:
           echo "${{ github.run_id }}" > run_id.txt
 
       - name: Upload Workflow Run ID
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         env:
           ARTIFACT_RETENTION_DAYS: ${{ vars.ARTIFACT_RETENTION_DAYS }}
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -45,7 +45,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Determine artifact name
         run: echo "ARTIFACT_NAME=collections-to-promote-from-${{ github.event.inputs.pr_number }}" >> $GITHUB_ENV

--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -49,7 +49,7 @@ jobs:
     needs: check-conditions
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get Workflow Run ID Artifact
         run: |


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-architecture/issues/569

-  actions/checkout@v4 pinned to [v4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683)
- actions/setup-python@v4 pinned to [v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0) and [v4.8.0](https://github.com/actions/setup-python/commit/b64ffcaf5b410884ad320a9cfac8866006a109aa)
- tj-actions/changed-files@v45 pinned to [v46.0.1](https://github.com/tj-actions/changed-files/commit/2f7c5bfce28377bc069a65ba478de0a74aa0ca32)
- actions/setup-python@v5 pinned to [v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)
- actions/upload-artifact@v4 pinned to [v4.6.1](https://github.com/actions/upload-artifact/commit/4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)