### PR TITLE
Add gpmimergdf collection

### DIFF
--- a/ingestion-data/staging/dataset-config/GPM_3IMERGDF.json
+++ b/ingestion-data/staging/dataset-config/GPM_3IMERGDF.json
@@ -1,152 +1,53 @@
 {
-  "id": "GPM_3IMERGDF",
   "type": "Collection",
-  "links": [
-    {
-      "rel": "items",
-      "type": "application/geo+json",
-      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF/items"
-    },
-    {
-      "rel": "parent",
-      "type": "application/json",
-      "href": "https://staging.openveda.cloud/api/stac/"
-    },
-    {
-      "rel": "root",
-      "type": "application/json",
-      "href": "https://staging.openveda.cloud/api/stac/"
-    },
-    {
-      "rel": "self",
-      "type": "application/json",
-      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF"
-    },
-    {
-      "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
-      "type": "application/schema+json",
-      "title": "Queryables",
-      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF/queryables"
-    }
-  ],
-  "title": null,
-  "assets": null,
-  "extent": {
-    "spatial": {
-      "bbox": [
-        [
-          -180.0,
-          -90.0,
-          180.0,
-          90.0
-        ]
-      ]
-    },
-    "temporal": {
-      "interval": [
-        [
-          "2000-06-01T00:00:00+00:00",
-          null
-        ]
-      ]
-    }
-  },
-  "license": "CC0-1.0",
-  "renders": {
-    "randomError": {
-      "title": "Renders configuration for randomError",
-      "backend": "xarray",
-      "rescale": [
-        [
-          0,
-          17469
-        ]
-      ],
-      "resampling": "average",
-      "colormap_name": "reds"
-    },
-    "precipitation": {
-      "title": "Renders configuration for precipitation",
-      "backend": "xarray",
-      "rescale": [
-        [
-          0,
-          48
-        ]
-      ],
-      "resampling": "average",
-      "colormap_name": "cfastie"
-    },
-    "MWprecipitation": {
-      "title": "Renders configuration for MWprecipitation",
-      "backend": "xarray",
-      "rescale": [
-        [
-          0,
-          50
-        ]
-      ],
-      "resampling": "average",
-      "colormap_name": "cfastie"
-    }
-  },
-  "keywords": null,
-  "providers": [
-    {
-      "url": "https://disc.gsfc.nasa.gov/",
-      "name": "NASA/GSFC/SED/ESD/GCDC/GESDISC",
-      "roles": [],
-      "description": "Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Global Change Data Center, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA"
-    }
-  ],
-  "summaries": null,
-  "description": "\nVersion 07 is the current version of the data set. Older versions will no longer be available and have been superseded by Version 07.\n\nThe Integrated Multi-satellitE Retrievals for GPM (IMERG) IMERG is a NASA product estimating global surface precipitation rates at a high resolution of 0.1° every half-hour beginning 2000.  It is part of the joint NASA-JAXA Global Precipitation Measurement (GPM) mission, using the GPM Core Observatory satellite as the standard to combine precipitation observations from an international constellation of satellites using advanced techniques.  IMERG can be used for global-scale applications as well as over regions with sparse or no reliable surface observations.  The fine spatial and temporal resolution of IMERG data allows them to be accumulated to the scale of the application for increased skill.  IMERG has three Runs with varying latencies in response to a range of application needs: rapid-response applications (Early Run, 4-h latency), same/next-day applications (Late Run, 14-h latency), and post-real-time research (Final Run, 3.5-month latency).  While IMERG strives for consistency and accuracy, satellite estimates of precipitation are expected to have lower skill over frozen surfaces, complex terrain, and coastal zones.  As well, the changing GPM satellite constellation over time may introduce artifacts that affect studies focusing on multi-year changes.\n\nThis dataset is the GPM Level 3 IMERG  *Final* Daily  10 x 10 km (GPM_3IMERGDF) derived from the half-hourly GPM_3IMERGHH.  The derived result represents the Final estimate of the daily mean precipitation rate in mm/day. The dataset is produced by first computing the mean precipitation rate in (mm/hour) in every grid cell, and then multiplying the result by 24.  This minimizes the possible dry bias in versions before \"07\", in the simple daily totals  for cells where less than 48 half-hourly observations are valid for the day. The latter under-sampling is very rare in the combined microwave-infrared and rain gauge  dataset, variable \"precipitation\",  and appears in higher latitudes. Thus, in most cases users of global \"precipitation\" data will not notice any difference. This correction, however, is noticeable in the high-quality microwave retrieval, variable \"MWprecipitation\", where the occurrence of less than 48 valid half-hourly samples per day is very common. The counts of the valid half-hourly samples per day have always been provided as a separate variable, and users of daily data were advised to pay close attention to that variable and use it to calculate the correct precipitation daily rates. Starting with version \"07\", this is done in production to minimize possible misinterpretations of the data. The counts are still provided in the data, but they are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThe latency of the derived *Final* Daily product depends on the delivery of the IMERG *Final* Half-Hourly product GPM_IMERGHH. Since the latter are delivered in a batch, once per month for the entire month, with 2-3 months latency, so will be the latency for the Final Daily, plus about 24 hours. Thus, e.g. the Dailies for January  can be expected to appear no earlier than April 2. \n\n\n\nThe daily mean rate (mm/day) is derived by first computing the mean precipitation rate (mm/hour) in a grid cell for the data day, and then multiplying the result by 24.  Thus, for every grid cell we have                \n\nPdaily_mean     = SUM{Pi * 1[Pi valid]} / Pdaily_cnt  * 24, i=[1,Nf]\n\nWhere:\nPdaily_cnt = SUM{1[Pi valid]}\n\nPi              - half-hourly input, in (mm/hr)\nNf              - Number of half-hourly files per day, Nf=48\n1[.]            - Indicator function; 1 when Pi is valid, 0 otherwise\nPdaily_cnt      - Number of valid retrievals in a grid cell per day.\n\nGrid cells for which Pdaily_cnt=0, are set to fill value in the Daily files.\nNote that Pi=0 is a valid value.\n\nPdaily_cnt are provided in the data files as variables \"precipitation_cnt\" and \"MWprecipitation_cnt\", for correspondingly the microwave-IR-gauge and microwave-only retrievals. They are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThere are various ways the daily error could be estimated from the source half-hourly random error (variable \"randomError\"). The daily error provided in the data files is calculated in a fashion similar to the daily mean precipitation rate. First, the mean of the squared half-hourly \"randomError\"  for the day is computed, and the resulting (mm^2/hr) is converted to (mm^2/day). Finally, square root is taken to get the result in (mm/day):\n\nPerr_daily = { SUM{ (Perr_i)^2 * 1[Perr_i valid] ) } / Ncnt_err  * 24}^0.5, i=[1,Nf]\nNcnt_err   = SUM( 1[Perr_i valid] )\n\nwhere:\nPerr_i\t\t- half-hourly input, \"randomError\", (mm/hr)\nPerr_daily\t- Magnitude of the daily error, (mm/day)\nNcnt_err\t\t- Number of valid half-hour error estimates\n\nAgain, the sum of squared \"randomError\" can be reconstructed, and other estimates can be derived using the available counts in the Daily files.\n",
-  "item_assets": null,
+  "id": "GPM_3IMERGDF",
   "stac_version": "1.0.0",
-  "cube:variables": {
-    "time_bnds": {
-      "type": "data",
-      "attrs": {},
-      "shape": [
-        null,
-        2
+  "description": "\nVersion 07 is the current version of the data set. Older versions will no longer be available and have been superseded by Version 07.\n\nThe Integrated Multi-satellitE Retrievals for GPM (IMERG) IMERG is a NASA product estimating global surface precipitation rates at a high resolution of 0.1\u00b0 every half-hour beginning 2000.  It is part of the joint NASA-JAXA Global Precipitation Measurement (GPM) mission, using the GPM Core Observatory satellite as the standard to combine precipitation observations from an international constellation of satellites using advanced techniques.  IMERG can be used for global-scale applications as well as over regions with sparse or no reliable surface observations.  The fine spatial and temporal resolution of IMERG data allows them to be accumulated to the scale of the application for increased skill.  IMERG has three Runs with varying latencies in response to a range of application needs: rapid-response applications (Early Run, 4-h latency), same/next-day applications (Late Run, 14-h latency), and post-real-time research (Final Run, 3.5-month latency).  While IMERG strives for consistency and accuracy, satellite estimates of precipitation are expected to have lower skill over frozen surfaces, complex terrain, and coastal zones.  As well, the changing GPM satellite constellation over time may introduce artifacts that affect studies focusing on multi-year changes.\n\nThis dataset is the GPM Level 3 IMERG  *Final* Daily  10 x 10 km (GPM_3IMERGDF) derived from the half-hourly GPM_3IMERGHH.  The derived result represents the Final estimate of the daily mean precipitation rate in mm/day. The dataset is produced by first computing the mean precipitation rate in (mm/hour) in every grid cell, and then multiplying the result by 24.  This minimizes the possible dry bias in versions before \"07\", in the simple daily totals  for cells where less than 48 half-hourly observations are valid for the day. The latter under-sampling is very rare in the combined microwave-infrared and rain gauge  dataset, variable \"precipitation\",  and appears in higher latitudes. Thus, in most cases users of global \"precipitation\" data will not notice any difference. This correction, however, is noticeable in the high-quality microwave retrieval, variable \"MWprecipitation\", where the occurrence of less than 48 valid half-hourly samples per day is very common. The counts of the valid half-hourly samples per day have always been provided as a separate variable, and users of daily data were advised to pay close attention to that variable and use it to calculate the correct precipitation daily rates. Starting with version \"07\", this is done in production to minimize possible misinterpretations of the data. The counts are still provided in the data, but they are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThe latency of the derived *Final* Daily product depends on the delivery of the IMERG *Final* Half-Hourly product GPM_IMERGHH. Since the latter are delivered in a batch, once per month for the entire month, with up to 4 months latency, so will be the latency for the Final Daily, plus about 24 hours. Thus, e.g. the Dailies for January  can be expected to appear no earlier than April 2. \n\n\n\nThe daily mean rate (mm/day) is derived by first computing the mean precipitation rate (mm/hour) in a grid cell for the data day, and then multiplying the result by 24.  Thus, for every grid cell we have                \n\nPdaily_mean     = SUM{Pi * 1[Pi valid]} / Pdaily_cnt  * 24, i=[1,Nf]\n\nWhere:\nPdaily_cnt = SUM{1[Pi valid]}\n\nPi              - half-hourly input, in (mm/hr)\nNf              - Number of half-hourly files per day, Nf=48\n1[.]            - Indicator function; 1 when Pi is valid, 0 otherwise\nPdaily_cnt      - Number of valid retrievals in a grid cell per day.\n\nGrid cells for which Pdaily_cnt=0, are set to fill value in the Daily files.\nNote that Pi=0 is a valid value.\n\nPdaily_cnt are provided in the data files as variables \"precipitation_cnt\" and \"MWprecipitation_cnt\", for correspondingly the microwave-IR-gauge and microwave-only retrievals. They are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThere are various ways the daily error could be estimated from the source half-hourly random error (variable \"randomError\"). The daily error provided in the data files is calculated in a fashion similar to the daily mean precipitation rate. First, the mean of the squared half-hourly \"randomError\"  for the day is computed, and the resulting (mm^2/hr) is converted to (mm^2/day). Finally, square root is taken to get the result in (mm/day):\n\nPerr_daily = { SUM{ (Perr_i)^2 * 1[Perr_i valid] ) } / Ncnt_err  * 24}^0.5, i=[1,Nf]\nNcnt_err   = SUM( 1[Perr_i valid] )\n\nwhere:\nPerr_i\t\t- half-hourly input, \"randomError\", (mm/hr)\nPerr_daily\t- Magnitude of the daily error, (mm/day)\nNcnt_err\t\t- Number of valid half-hour error estimates\n\nAgain, the sum of squared \"randomError\" can be reconstructed, and other estimates can be derived using the available counts in the Daily files.\n",
+  "links": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
+  ],
+  "collection_concept_id": "C2723754864-GES_DISC",
+  "cube:dimensions": {
+    "time": {
+      "extent": [
+        "1998-01-01T00:00:00Z",
+        null
       ],
-      "chunks": [
-        1,
-        2
-      ],
-      "dimensions": [
-        "time",
-        "nv"
-      ]
+      "description": "time",
+      "step": "P1D",
+      "type": "temporal"
     },
-    "randomError": {
+    "lon": {
+      "axis": "x",
+      "extent": [
+        -179.9499969482422,
+        179.9499969482422
+      ],
+      "description": "Longitude",
+      "reference_system": 4326,
+      "type": "spatial"
+    },
+    "lat": {
+      "axis": "y",
+      "extent": [
+        -89.95,
+        89.95
+      ],
+      "description": "Latitude",
+      "reference_system": 4326,
+      "type": "spatial"
+    }
+  },
+  "cube:variables": {
+    "precipitation": {
       "type": "data",
-      "unit": "mm/day",
-      "attrs": {
-        "units": "mm/day",
-        "long_name": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate"
-      },
-      "shape": [
-        null,
-        3600,
-        1800
-      ],
-      "chunks": [
-        1,
-        3600,
-        900
-      ],
-      "renders": "randomError",
+      "description": "Daily mean precipitation rate (combined microwave-IR) estimate. Formerly precipitationCal.",
       "dimensions": [
         "time",
         "lon",
         "lat"
       ],
-      "description": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate"
-    },
-    "precipitation": {
-      "type": "data",
       "unit": "mm/day",
       "attrs": {
         "units": "mm/day",
@@ -162,16 +63,64 @@
         3600,
         900
       ],
-      "renders": "precipitation",
+      "renders": "precipitation"
+    },
+    "precipitation_cnt": {
+      "type": "data",
+      "description": "Count of all valid half-hourly precipitation retrievals for the day",
       "dimensions": [
         "time",
         "lon",
         "lat"
       ],
-      "description": "Daily mean precipitation rate (combined microwave-IR) estimate. Formerly precipitationCal."
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of all valid half-hourly precipitation retrievals for the day"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ]
+    },
+    "precipitation_cnt_cond": {
+      "type": "data",
+      "description": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ]
     },
     "MWprecipitation": {
       "type": "data",
+      "description": "Daily mean High Quality precipitation rate from all available microwave sources. Formerly HQprecipitation.",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
       "unit": "mm/day",
       "attrs": {
         "units": "mm/day",
@@ -187,64 +136,16 @@
         3600,
         900
       ],
-      "renders": "MWprecipitation",
-      "dimensions": [
-        "time",
-        "lon",
-        "lat"
-      ],
-      "description": "Daily mean High Quality precipitation rate from all available microwave sources. Formerly HQprecipitation."
-    },
-    "randomError_cnt": {
-      "type": "data",
-      "unit": "count",
-      "attrs": {
-        "units": "count",
-        "long_name": "Count of valid half-hourly randomError retrievals for the day"
-      },
-      "shape": [
-        null,
-        3600,
-        1800
-      ],
-      "chunks": [
-        1,
-        3600,
-        900
-      ],
-      "dimensions": [
-        "time",
-        "lon",
-        "lat"
-      ],
-      "description": "Count of valid half-hourly randomError retrievals for the day"
-    },
-    "precipitation_cnt": {
-      "type": "data",
-      "unit": "count",
-      "attrs": {
-        "units": "count",
-        "long_name": "Count of all valid half-hourly precipitation retrievals for the day"
-      },
-      "shape": [
-        null,
-        3600,
-        1800
-      ],
-      "chunks": [
-        1,
-        3600,
-        900
-      ],
-      "dimensions": [
-        "time",
-        "lon",
-        "lat"
-      ],
-      "description": "Count of all valid half-hourly precipitation retrievals for the day"
+      "renders": "MWprecipitation"
     },
     "MWprecipitation_cnt": {
       "type": "data",
+      "description": "Count of all valid half-hourly MWprecipitation retrievals for the day",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
       "unit": "count",
       "attrs": {
         "units": "count",
@@ -259,40 +160,16 @@
         1,
         3600,
         900
-      ],
-      "dimensions": [
-        "time",
-        "lon",
-        "lat"
-      ],
-      "description": "Count of all valid half-hourly MWprecipitation retrievals for the day"
-    },
-    "precipitation_cnt_cond": {
-      "type": "data",
-      "unit": "count",
-      "attrs": {
-        "units": "count",
-        "long_name": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
-      },
-      "shape": [
-        null,
-        3600,
-        1800
-      ],
-      "chunks": [
-        1,
-        3600,
-        900
-      ],
-      "dimensions": [
-        "time",
-        "lon",
-        "lat"
-      ],
-      "description": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+      ]
     },
     "MWprecipitation_cnt_cond": {
       "type": "data",
+      "description": "Count of half-hourly MWprecipitation retrievals for the day where precipitation is at least 0.01 mm/hr",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
       "unit": "count",
       "attrs": {
         "units": "count",
@@ -307,16 +184,65 @@
         1,
         3600,
         900
-      ],
+      ]
+    },
+    "randomError": {
+      "type": "data",
+      "description": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate",
       "dimensions": [
         "time",
         "lon",
         "lat"
       ],
-      "description": "Count of half-hourly MWprecipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+      "unit": "mm/day",
+      "attrs": {
+        "units": "mm/day",
+        "long_name": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "renders": "randomError"
+    },
+    "randomError_cnt": {
+      "type": "data",
+      "description": "Count of valid half-hourly randomError retrievals for the day",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of valid half-hourly randomError retrievals for the day"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ]
     },
     "probabilityLiquidPrecipitation": {
       "type": "data",
+      "description": "Probability of liquid precipitation estimated with a diagnostic parameterization using ancillary data. 0=missing values; 1=likely solid; 100=likely liquid or no precipitation.  Screen by positive precipitation or precipitation_cnt_cond to locate meaningful probabilities.",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
       "unit": "percent",
       "attrs": {
         "units": "percent",
@@ -332,50 +258,92 @@
         1,
         3600,
         900
-      ],
+      ]
+    },
+    "time_bnds": {
+      "type": "data",
       "dimensions": [
         "time",
-        "lon",
-        "lat"
+        "nv"
       ],
-      "description": "Probability of liquid precipitation estimated with a diagnostic parameterization using ancillary data. 0=missing values; 1=likely solid; 100=likely liquid or no precipitation.  Screen by positive precipitation or precipitation_cnt_cond to locate meaningful probabilities."
+      "attrs": {},
+      "shape": [
+        null,
+        2
+      ],
+      "chunks": [
+        1,
+        2
+      ]
     }
   },
-  "cube:dimensions": {
-    "lat": {
-      "axis": "y",
-      "type": "spatial",
-      "extent": [
-        -89.95,
-        89.95
+  "renders": {
+    "precipitation": {
+      "title": "Renders configuration for precipitation",
+      "resampling": "average",
+      "colormap_name": "cfastie",
+      "rescale": [
+        [
+          0,
+          48
+        ]
       ],
-      "description": "Latitude",
-      "reference_system": 4326
+      "backend": "xarray"
     },
-    "lon": {
-      "axis": "x",
-      "type": "spatial",
-      "extent": [
-        -179.9499969482422,
-        179.9499969482422
+    "MWprecipitation": {
+      "title": "Renders configuration for MWprecipitation",
+      "resampling": "average",
+      "colormap_name": "cfastie",
+      "rescale": [
+        [
+          0,
+          50
+        ]
       ],
-      "description": "Longitude",
-      "reference_system": 4326
+      "backend": "xarray"
     },
-    "time": {
-      "step": "P1D",
-      "type": "temporal",
-      "extent": [
-        "2000-06-01T00:00:00Z",
-        null
+    "randomError": {
+      "title": "Renders configuration for randomError",
+      "resampling": "average",
+      "colormap_name": "reds",
+      "rescale": [
+        [
+          0,
+          17469
+        ]
       ],
-      "description": "time"
+      "backend": "xarray"
     }
   },
-  "stac_extensions": [
-    "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
-  ],
-  "collection_concept_id": "C2723754864-GES_DISC",
-  "dashboard:is_periodic": false,
-  "dashboard:time_density": null
+  "dashboard:is_periodic": true,
+  "dashboard:time_density": "day",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "1998-01-01T00:00:00Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "CC0-1.0",
+  "providers": [
+    {
+      "name": "NASA/GSFC/SED/ESD/TISL/GESDISC",
+      "description": "Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Terrestrial Information Systems Laboratory, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA",
+      "roles": [],
+      "url": "https://disc.gsfc.nasa.gov/"
+    }
+  ]
 }

--- a/ingestion-data/staging/dataset-config/GPM_3IMERGDF.json
+++ b/ingestion-data/staging/dataset-config/GPM_3IMERGDF.json
@@ -1,0 +1,381 @@
+{
+  "id": "GPM_3IMERGDF",
+  "type": "Collection",
+  "links": [
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF/items"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://staging.openveda.cloud/api/stac/"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://staging.openveda.cloud/api/stac/"
+    },
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+      "type": "application/schema+json",
+      "title": "Queryables",
+      "href": "https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF/queryables"
+    }
+  ],
+  "title": null,
+  "assets": null,
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2000-06-01T00:00:00+00:00",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "CC0-1.0",
+  "renders": {
+    "randomError": {
+      "title": "Renders configuration for randomError",
+      "backend": "xarray",
+      "rescale": [
+        [
+          0,
+          17469
+        ]
+      ],
+      "resampling": "average",
+      "colormap_name": "reds"
+    },
+    "precipitation": {
+      "title": "Renders configuration for precipitation",
+      "backend": "xarray",
+      "rescale": [
+        [
+          0,
+          48
+        ]
+      ],
+      "resampling": "average",
+      "colormap_name": "cfastie"
+    },
+    "MWprecipitation": {
+      "title": "Renders configuration for MWprecipitation",
+      "backend": "xarray",
+      "rescale": [
+        [
+          0,
+          50
+        ]
+      ],
+      "resampling": "average",
+      "colormap_name": "cfastie"
+    }
+  },
+  "keywords": null,
+  "providers": [
+    {
+      "url": "https://disc.gsfc.nasa.gov/",
+      "name": "NASA/GSFC/SED/ESD/GCDC/GESDISC",
+      "roles": [],
+      "description": "Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Global Change Data Center, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA"
+    }
+  ],
+  "summaries": null,
+  "description": "\nVersion 07 is the current version of the data set. Older versions will no longer be available and have been superseded by Version 07.\n\nThe Integrated Multi-satellitE Retrievals for GPM (IMERG) IMERG is a NASA product estimating global surface precipitation rates at a high resolution of 0.1° every half-hour beginning 2000.  It is part of the joint NASA-JAXA Global Precipitation Measurement (GPM) mission, using the GPM Core Observatory satellite as the standard to combine precipitation observations from an international constellation of satellites using advanced techniques.  IMERG can be used for global-scale applications as well as over regions with sparse or no reliable surface observations.  The fine spatial and temporal resolution of IMERG data allows them to be accumulated to the scale of the application for increased skill.  IMERG has three Runs with varying latencies in response to a range of application needs: rapid-response applications (Early Run, 4-h latency), same/next-day applications (Late Run, 14-h latency), and post-real-time research (Final Run, 3.5-month latency).  While IMERG strives for consistency and accuracy, satellite estimates of precipitation are expected to have lower skill over frozen surfaces, complex terrain, and coastal zones.  As well, the changing GPM satellite constellation over time may introduce artifacts that affect studies focusing on multi-year changes.\n\nThis dataset is the GPM Level 3 IMERG  *Final* Daily  10 x 10 km (GPM_3IMERGDF) derived from the half-hourly GPM_3IMERGHH.  The derived result represents the Final estimate of the daily mean precipitation rate in mm/day. The dataset is produced by first computing the mean precipitation rate in (mm/hour) in every grid cell, and then multiplying the result by 24.  This minimizes the possible dry bias in versions before \"07\", in the simple daily totals  for cells where less than 48 half-hourly observations are valid for the day. The latter under-sampling is very rare in the combined microwave-infrared and rain gauge  dataset, variable \"precipitation\",  and appears in higher latitudes. Thus, in most cases users of global \"precipitation\" data will not notice any difference. This correction, however, is noticeable in the high-quality microwave retrieval, variable \"MWprecipitation\", where the occurrence of less than 48 valid half-hourly samples per day is very common. The counts of the valid half-hourly samples per day have always been provided as a separate variable, and users of daily data were advised to pay close attention to that variable and use it to calculate the correct precipitation daily rates. Starting with version \"07\", this is done in production to minimize possible misinterpretations of the data. The counts are still provided in the data, but they are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThe latency of the derived *Final* Daily product depends on the delivery of the IMERG *Final* Half-Hourly product GPM_IMERGHH. Since the latter are delivered in a batch, once per month for the entire month, with 2-3 months latency, so will be the latency for the Final Daily, plus about 24 hours. Thus, e.g. the Dailies for January  can be expected to appear no earlier than April 2. \n\n\n\nThe daily mean rate (mm/day) is derived by first computing the mean precipitation rate (mm/hour) in a grid cell for the data day, and then multiplying the result by 24.  Thus, for every grid cell we have                \n\nPdaily_mean     = SUM{Pi * 1[Pi valid]} / Pdaily_cnt  * 24, i=[1,Nf]\n\nWhere:\nPdaily_cnt = SUM{1[Pi valid]}\n\nPi              - half-hourly input, in (mm/hr)\nNf              - Number of half-hourly files per day, Nf=48\n1[.]            - Indicator function; 1 when Pi is valid, 0 otherwise\nPdaily_cnt      - Number of valid retrievals in a grid cell per day.\n\nGrid cells for which Pdaily_cnt=0, are set to fill value in the Daily files.\nNote that Pi=0 is a valid value.\n\nPdaily_cnt are provided in the data files as variables \"precipitation_cnt\" and \"MWprecipitation_cnt\", for correspondingly the microwave-IR-gauge and microwave-only retrievals. They are only given to gauge the significance of the daily rates, and reconstruct the simple totals if someone wishes to do so. \n\nThere are various ways the daily error could be estimated from the source half-hourly random error (variable \"randomError\"). The daily error provided in the data files is calculated in a fashion similar to the daily mean precipitation rate. First, the mean of the squared half-hourly \"randomError\"  for the day is computed, and the resulting (mm^2/hr) is converted to (mm^2/day). Finally, square root is taken to get the result in (mm/day):\n\nPerr_daily = { SUM{ (Perr_i)^2 * 1[Perr_i valid] ) } / Ncnt_err  * 24}^0.5, i=[1,Nf]\nNcnt_err   = SUM( 1[Perr_i valid] )\n\nwhere:\nPerr_i\t\t- half-hourly input, \"randomError\", (mm/hr)\nPerr_daily\t- Magnitude of the daily error, (mm/day)\nNcnt_err\t\t- Number of valid half-hour error estimates\n\nAgain, the sum of squared \"randomError\" can be reconstructed, and other estimates can be derived using the available counts in the Daily files.\n",
+  "item_assets": null,
+  "stac_version": "1.0.0",
+  "cube:variables": {
+    "time_bnds": {
+      "type": "data",
+      "attrs": {},
+      "shape": [
+        null,
+        2
+      ],
+      "chunks": [
+        1,
+        2
+      ],
+      "dimensions": [
+        "time",
+        "nv"
+      ]
+    },
+    "randomError": {
+      "type": "data",
+      "unit": "mm/day",
+      "attrs": {
+        "units": "mm/day",
+        "long_name": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "renders": "randomError",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Root-mean-square error estimate for combined microwave-IR daily precipitation rate"
+    },
+    "precipitation": {
+      "type": "data",
+      "unit": "mm/day",
+      "attrs": {
+        "units": "mm/day",
+        "long_name": "Daily mean precipitation rate (combined microwave-IR) estimate. Formerly precipitationCal."
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "renders": "precipitation",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Daily mean precipitation rate (combined microwave-IR) estimate. Formerly precipitationCal."
+    },
+    "MWprecipitation": {
+      "type": "data",
+      "unit": "mm/day",
+      "attrs": {
+        "units": "mm/day",
+        "long_name": "Daily mean High Quality precipitation rate from all available microwave sources. Formerly HQprecipitation."
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "renders": "MWprecipitation",
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Daily mean High Quality precipitation rate from all available microwave sources. Formerly HQprecipitation."
+    },
+    "randomError_cnt": {
+      "type": "data",
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of valid half-hourly randomError retrievals for the day"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Count of valid half-hourly randomError retrievals for the day"
+    },
+    "precipitation_cnt": {
+      "type": "data",
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of all valid half-hourly precipitation retrievals for the day"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Count of all valid half-hourly precipitation retrievals for the day"
+    },
+    "MWprecipitation_cnt": {
+      "type": "data",
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of all valid half-hourly MWprecipitation retrievals for the day"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Count of all valid half-hourly MWprecipitation retrievals for the day"
+    },
+    "precipitation_cnt_cond": {
+      "type": "data",
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Count of half-hourly precipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+    },
+    "MWprecipitation_cnt_cond": {
+      "type": "data",
+      "unit": "count",
+      "attrs": {
+        "units": "count",
+        "long_name": "Count of half-hourly MWprecipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Count of half-hourly MWprecipitation retrievals for the day where precipitation is at least 0.01 mm/hr"
+    },
+    "probabilityLiquidPrecipitation": {
+      "type": "data",
+      "unit": "percent",
+      "attrs": {
+        "units": "percent",
+        "long_name": "Probability of liquid precipitation",
+        "description": "Probability of liquid precipitation estimated with a diagnostic parameterization using ancillary data. 0=missing values; 1=likely solid; 100=likely liquid or no precipitation.  Screen by positive precipitation or precipitation_cnt_cond to locate meaningful probabilities."
+      },
+      "shape": [
+        null,
+        3600,
+        1800
+      ],
+      "chunks": [
+        1,
+        3600,
+        900
+      ],
+      "dimensions": [
+        "time",
+        "lon",
+        "lat"
+      ],
+      "description": "Probability of liquid precipitation estimated with a diagnostic parameterization using ancillary data. 0=missing values; 1=likely solid; 100=likely liquid or no precipitation.  Screen by positive precipitation or precipitation_cnt_cond to locate meaningful probabilities."
+    }
+  },
+  "cube:dimensions": {
+    "lat": {
+      "axis": "y",
+      "type": "spatial",
+      "extent": [
+        -89.95,
+        89.95
+      ],
+      "description": "Latitude",
+      "reference_system": 4326
+    },
+    "lon": {
+      "axis": "x",
+      "type": "spatial",
+      "extent": [
+        -179.9499969482422,
+        179.9499969482422
+      ],
+      "description": "Longitude",
+      "reference_system": 4326
+    },
+    "time": {
+      "step": "P1D",
+      "type": "temporal",
+      "extent": [
+        "2000-06-01T00:00:00Z",
+        null
+      ],
+      "description": "time"
+    }
+  },
+  "stac_extensions": [
+    "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
+  ],
+  "collection_concept_id": "C2723754864-GES_DISC",
+  "dashboard:is_periodic": false,
+  "dashboard:time_density": null
+}

--- a/transformation-scripts/create-stac-for-cmr-collections.ipynb
+++ b/transformation-scripts/create-stac-for-cmr-collections.ipynb
@@ -1,0 +1,558 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd5607aa-2e4e-4f14-a56b-40ec6cdb9c50",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "title: Create STAC metadata for a CMR collection, using GPM IMERG\n",
+    "description: Tutorial for creating STAC metadata for a collection in CMR\n",
+    "author: Aimee Barciauskas\n",
+    "date: June 9, 2025\n",
+    "execute:\n",
+    "  freeze: true\n",
+    "  cache: true\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b260955",
+   "metadata": {},
+   "source": [
+    "## Run this notebook\n",
+    "\n",
+    "This notebook was written on a VEDA JupyterHub instance.\n",
+    "\n",
+    "See [VEDA Interactive Compute and Processing Environment docs](https://docs.openveda.cloud/user-guide/scientific-computing/getting-access.html) for information about how to gain access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "279606ac-6886-4cf0-8248-e26a84694a72",
+   "metadata": {},
+   "source": [
+    "## Approach\n",
+    "\n",
+    "This notebook creates STAC collection metadata for the [GPM IMERG Final Precipitation L3 1 day 0.1 degree x 0.1 degree V07 (GPM_3IMERGDF) at GES DISC](https://search.earthdata.nasa.gov/search/granules?p=C2723754864-GES_DISC) dataset. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eca29984-ac2b-4f41-8ae2-d8d57c8968ef",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install and import necessary libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ce71f2c2-0b47-4be5-9bad-d51a0ce56015",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install xstac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "67e37cc9-6022-46c2-aa20-4bb87dd502f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import earthaccess\n",
+    "import json\n",
+    "from datetime import datetime\n",
+    "import pandas as pd\n",
+    "import pystac\n",
+    "import requests\n",
+    "import s3fs\n",
+    "import xstac\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e256d2e4-6ff0-461d-a847-794aae86e444",
+   "metadata": {},
+   "source": [
+    "## Step 2: Get Collection metadata from CMR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0d11fbe9-f562-481c-8648-f43b17896665",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your Earthdata Login username:  aimeeb\n",
+      "Enter your Earthdata password:  ········\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<earthaccess.auth.Auth at 0x7f5cbf09cef0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "earthaccess.login()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e3e24555-e74f-491a-a159-d3b26174a24c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "collection_identifier = 'GPM_3IMERGDF.07'\n",
+    "collection_config = {\n",
+    "    \"short_name\": \"GPM_3IMERGDF\",\n",
+    "    \"version\": \"07\",\n",
+    "    \"temporal_step\": \"P1D\",\n",
+    "    \"variables\": {\n",
+    "      \"precipitation\": {\n",
+    "        \"rescale\": [[0, 48]],\n",
+    "        \"colormap\": \"cfastie\"\n",
+    "      },\n",
+    "      \"MWprecipitation\": {\n",
+    "        \"rescale\": [[0, 50]],\n",
+    "        \"colormap\": \"cfastie\"\n",
+    "      },\n",
+    "      \"randomError\": {\n",
+    "        \"rescale\": [[0, 17469]],\n",
+    "        \"colormap\": \"reds\"\n",
+    "      }\n",
+    "    },\n",
+    "    \"reference_system\": \"4326\"\n",
+    "}\n",
+    "short_name, version, temporal_step, variables, reference_system = collection_config.values()\n",
+    "collection_query = earthaccess.collection_query()\n",
+    "r = collection_query.short_name(short_name).version(version)\n",
+    "cmr_collection = r.get(1)[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c65d201-50b4-477f-8a7f-4cf85bf66ceb",
+   "metadata": {},
+   "source": [
+    "Pick out one granule to open for data cube dimensions and variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fa6ab048-e747-46dc-8c55-b9d3aaa06a58",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "first_result = earthaccess.search_data(\n",
+    "    short_name=short_name,\n",
+    "    version=version,\n",
+    "    cloud_hosted=True,\n",
+    "    count=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "899f6e9b-ea60-4e39-9dd8-1b46fcbe48d2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Collection: {'ShortName': 'GPM_3IMERGDF', 'Version': '07'}\n",
+       " Spatial coverage: {'HorizontalSpatialDomain': {'Geometry': {'BoundingRectangles': [{'WestBoundingCoordinate': -180.0, 'EastBoundingCoordinate': 180.0, 'NorthBoundingCoordinate': 90.0, 'SouthBoundingCoordinate': -90.0}]}}}\n",
+       " Temporal coverage: {'RangeDateTime': {'BeginningDateTime': '1998-01-01T00:00:00.000Z', 'EndingDateTime': '1998-01-01T23:59:59.999Z'}}\n",
+       " Size(MB): 26.3265686035156\n",
+       " Data: ['https://data.gesdisc.earthdata.nasa.gov/data/GPM_L3/GPM_3IMERGDF.07/1998/01/3B-DAY.MS.MRG.3IMERG.19980101-S000000-E235959.V07B.nc4']]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "06221618-a2a7-4e8e-bfe0-e836e6ad1323",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'s3://gesdisc-cumulus-prod-protected/GPM_L3/GPM_3IMERGDF.07/1998/01/3B-DAY.MS.MRG.3IMERG.19980101-S000000-E235959.V07B.nc4'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s3_link = first_result[0].data_links(access='direct')[0]\n",
+    "s3_link"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9405cbcc-e001-4c75-93be-0b004ad51678",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.53 s, sys: 311 ms, total: 2.84 s\n",
+      "Wall time: 3.4 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "fs = s3fs.S3FileSystem(anon=False)\n",
+    "ds_s3 = xr.open_dataset(fs.open(s3_link), engine='h5netcdf', chunks={})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4449a055-779e-4024-a871-ddf107cb27d2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Step 3: Generate STAC metadata\n",
+    "\n",
+    "The spatial and temporal extents are extracted from the CMR collection metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "47cba6c5-2d6c-4829-8b49-ada67e6b5522",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "spatial_extent = cmr_collection['umm']['SpatialExtent']\n",
+    "bounding_rectangle = spatial_extent['HorizontalSpatialDomain']['Geometry']['BoundingRectangles'][0]\n",
+    "extent_list = [\n",
+    "    bounding_rectangle[\"WestBoundingCoordinate\"],\n",
+    "    bounding_rectangle[\"SouthBoundingCoordinate\"],   \n",
+    "    bounding_rectangle[\"EastBoundingCoordinate\"],\n",
+    "    bounding_rectangle[\"NorthBoundingCoordinate\"],    \n",
+    "]\n",
+    "spatial_extent = list(map(int, extent_list))\n",
+    "\n",
+    "temporal_extent = cmr_collection['umm']['TemporalExtents'][0]['RangeDateTimes'][0]\n",
+    "start = temporal_extent['BeginningDateTime']\n",
+    "end = temporal_extent.get('EndingDateTime', None)\n",
+    "\n",
+    "extent = pystac.Extent(\n",
+    "    spatial=pystac.SpatialExtent(bboxes=[spatial_extent]),\n",
+    "    temporal=pystac.TemporalExtent([[pd.to_datetime(start), pd.to_datetime(end)]])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3351996d-f124-410d-a6a2-55abcdb2aecb",
+   "metadata": {},
+   "source": [
+    "Add the provider information from CMR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e7dad951-557c-4121-b4fa-4c51ab4723a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmr_roles_to_pystac_roles = {\n",
+    "    'PROCESSOR': pystac.ProviderRole.PROCESSOR,\n",
+    "    'DISTRIBUTOR': pystac.ProviderRole.HOST\n",
+    "}\n",
+    "def create_providers_from_data_centers(data_centers):\n",
+    "    providers = []\n",
+    "\n",
+    "    for center in data_centers:\n",
+    "        # Extracting necessary information from each data center\n",
+    "        short_name = center.get(\"ShortName\", \"\")\n",
+    "        long_name = center.get(\"LongName\", \"\")\n",
+    "        roles = []\n",
+    "        for role in center.get(\"Roles\", []):\n",
+    "            if role in cmr_roles_to_pystac_roles:\n",
+    "                roles.append(cmr_roles_to_pystac_roles[role])\n",
+    "        url = next((url_info[\"URL\"] for url_info in center.get(\"ContactInformation\", {}).get(\"RelatedUrls\", []) \n",
+    "                    if url_info.get(\"URLContentType\") == \"DataCenterURL\"), None)\n",
+    "\n",
+    "        # Creating a PySTAC Provider object\n",
+    "        provider = pystac.Provider(name=short_name, description=long_name, roles=roles, url=url)\n",
+    "        providers.append(provider)\n",
+    "\n",
+    "    return providers\n",
+    "\n",
+    "data_centers = cmr_collection['umm']['DataCenters']\n",
+    "providers = create_providers_from_data_centers(data_centers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c2bb7f1-4eb3-4d6d-9fd2-f3800c2cf57e",
+   "metadata": {},
+   "source": [
+    "Put it all together to intialize a `pystac.Collection` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7a36bb5c-1425-4818-8d05-4c29bcd35590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_id = short_name.replace('.', '_')\n",
+    "description = cmr_collection['umm']['Abstract']\n",
+    "concept_id = cmr_collection['meta']['concept-id']\n",
+    "pystac_collection = pystac.Collection(\n",
+    "    id=_id,\n",
+    "    extent=extent,\n",
+    "    description=cmr_collection['umm']['Abstract'],\n",
+    "    providers=providers,\n",
+    "    stac_extensions=['https://stac-extensions.github.io/datacube/v2.0.0/schema.json'],\n",
+    "    license=\"CC0-1.0\",\n",
+    "    extra_fields={'collection_concept_id': concept_id}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f31a852-c727-4a46-97c8-44de1e965345",
+   "metadata": {},
+   "source": [
+    "That collection instance is used by `xstac` to generate additional metadata, specifically for the [`datacube extension`](https://github.com/stac-extensions/datacube) information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d66cd1e6-9c29-429d-b569-be5f6c69d6b4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json',\n",
+       " 'https://stac-extensions.github.io/datacube/v2.2.0/schema.json']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection_template = pystac_collection.to_dict()\n",
+    "\n",
+    "# see https://github.com/stac-utils/xstac/issues/30\n",
+    "for k, v in ds_s3.variables.items():\n",
+    "    attrs = {name: xr.backends.zarr.encode_zarr_attr_value(value) for name, value in v.attrs.items()}\n",
+    "    ds_s3[k].attrs = attrs\n",
+    "        \n",
+    "collection = xstac.xarray_to_stac(\n",
+    "    ds_s3,\n",
+    "    collection_template,\n",
+    "    temporal_dimension='time',\n",
+    "    temporal_step=temporal_step,\n",
+    "    x_dimension=\"lon\",\n",
+    "    y_dimension=\"lat\",\n",
+    "    reference_system=reference_system,\n",
+    "    validate=False\n",
+    ")\n",
+    "\n",
+    "collection.validate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80ce29f9-c3f4-432c-9cd2-d659ca0e63e4",
+   "metadata": {},
+   "source": [
+    "Set the second value for the time extent to `None` since the dataset is ongoing. Otherwise the extent is just the extent of the first file in the collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "84c1d969-4c8c-4b33-a4da-5144fc73115c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "collection.to_dict()['cube:dimensions']['time']['extent'][1] = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ae799bbb-06f8-499b-be53-c9ab86762ca7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cube_variables = collection.to_dict()['cube:variables']\n",
+    "for variable in cube_variables.keys():\n",
+    "    cube_variables[variable]['shape'][0] = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2f407c4-0356-45f5-aac0-c97e62e49e77",
+   "metadata": {},
+   "source": [
+    "Add [renders](https://github.com/stac-extensions/render) extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f7f0bc3c-1c23-4b3f-8f70-5b8bc40d3115",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "collection.extra_fields['renders'] = {}\n",
+    "for vname, vvalue in variables.items():\n",
+    "    collection.extra_fields['renders'][vname] = {\n",
+    "      \"title\": f\"Renders configuration for {vname}\",\n",
+    "      \"resampling\": \"average\",\n",
+    "      \"colormap_name\": vvalue['colormap'],\n",
+    "      \"rescale\": vvalue['rescale'],\n",
+    "      \"backend\": \"xarray\"\n",
+    "    }\n",
+    "    collection.to_dict()['cube:variables'][vname]['renders'] = vname"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fe0698b-9082-4516-b6d2-eec58fcab7ea",
+   "metadata": {},
+   "source": [
+    "Add dashboard fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "dd78b26c-1bd5-44f3-9b64-856b9de3a775",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection.extra_fields['dashboard:is_periodic'] = True\n",
+    "collection.extra_fields['dashboard:time_density'] = 'day'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8156274-d9c5-47c9-a869-e55f214d8a06",
+   "metadata": {},
+   "source": [
+    "## Step 4: Write to json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "42d3023b-b551-43c1-9984-22553eb41fb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(f\"../ingestion-data/staging/dataset-config/{collection.id}.json\", \"w+\") as f:\n",
+    "    f.write(json.dumps(collection.to_dict(), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a46e6b9-cb16-4515-a67c-bacb81cacd0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "differences noticed\n",
+    "- links absent in new file\n",
+    "- new start date (1998 instead of 2000)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/transformation-scripts/create-stac-for-cmr-collections.ipynb
+++ b/transformation-scripts/create-stac-for-cmr-collections.ipynb
@@ -520,18 +520,6 @@
     "with open(f\"../ingestion-data/staging/dataset-config/{collection.id}.json\", \"w+\") as f:\n",
     "    f.write(json.dumps(collection.to_dict(), indent=2))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7a46e6b9-cb16-4515-a67c-bacb81cacd0f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "differences noticed\n",
-    "- links absent in new file\n",
-    "- new start date (1998 instead of 2000)\n"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR includes a notebook and STAC json for the CMR collection `GPM_3IMERGDF` which is used as a demonstration of titiler-cmr in VEDA.

It is an update to the existing https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF to address https://github.com/NASA-IMPACT/veda-config/issues/865. 

There are some differences in the dataset metadata from what is in https://staging.openveda.cloud/api/stac/collections/GPM_3IMERGDF, but they are all minor:

#### 1. Links Array

Staging: Contains 5 link objects with various rel types (items, parent, root, self, queryables)
Updated (this PR): Empty array [] - _I assume these get added upon ingestion_

#### 2. Temporal Extent + Time Dimension Extent

Staging: "2000-06-01T00:00:00+00:00"
Updated: "1998-01-01T00:00:00Z"

I'm inquiring with Christine at GES DISC if I originally got this wrong or the extent has changed.

#### 3. Dashboard Properties

`dashboard:is_periodic`:

Staging: false
Updated: true

`dashboard:time_density`:

Staging: null
Updated: "day"

#### 4. Provider Information

Staging: "NASA/GSFC/SED/ESD/GCDC/GESDISC"
Updated: "NASA/GSFC/SED/ESD/TISL/GESDISC"

_This is pulled from CMR._

#### 5. Description Text

Staging: "with 2-3 months latency"
Updated: "with up to 4 months latency"

cc @hanbyul-here 