### PR TITLE
Include collection promotion

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,12 +120,12 @@ jobs:
           for file in ${ALL_CHANGED_FILES}; do
             echo $file
             if [ -f "$file" ]; then
-              if [[ "$file" == ingestion-data/staging/dataset-config/* ]]; then
+              if [[ "$file" == *"ingestion-data/staging/dataset-config/"* ]]; then
                 script_to_run="./scripts/promote_dataset.py"
                 # Datasets are required to have a `collection` field in their config
                 collection_id=$(jq -r '.collection' "$file")
                 config_type="Dataset"
-              elif [[ "$file" == ingestion-data/staging/collections/* ]]; then
+              elif [[ "$file" == *"ingestion-data/staging/collections/"* ]]; then
                 script_to_run="./scripts/promote_collection.py"
                 # Collections are required to have an `id` field
                 collection_id=$(jq -r '.id' "$file")

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,8 @@ on:
     branches: ['main']
     paths:
       # Run the workflow only if files inside this path are updated
-      - ingestion-data/staging/dataset-config/*.json
+      - 'ingestion-data/staging/dataset-config/**.json'
+      - 'ingestion-data/staging/collections/**.json'
 
   push:
     branches:
@@ -71,7 +72,9 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
-          files: ingestion-data/staging/dataset-config/**.json
+          files: |
+            ingestion-data/staging/dataset-config/**.json
+            ingestion-data/staging/collections/**.json
 
       # ACMR - Added, Copied, Modified, Renamed
       - name: List all newly added and changed files
@@ -117,12 +120,24 @@ jobs:
           for file in ${ALL_CHANGED_FILES}; do
             echo $file
             if [ -f "$file" ]; then
-              dataset_config=$(jq '.' "$file")
-              collection_id=$(jq -r '.collection' "$file")
+              if [[ "$file" == ingestion-data/staging/dataset-config/* ]]; then
+                script_to_run="./scripts/promote_dataset.py"
+                # Datasets are required to have a `collection` field in their config
+                collection_id=$(jq -r '.collection' "$file")
+                entity_type="Dataset"
+              elif [[ "$file" == ingestion-data/staging/collections/* ]]; then
+                script_to_run="./scripts/promote_collection.py"
+                # Collections are required to have an `id` field
+                collection_id=$(jq -r '.id' "$file")
+                entity_type="Collection"
+              else
+                echo "File $file is not in a recognized directory for ingestion (dataset-config or collections). Skipping."
+                continue
+              fi
 
-              echo "Publishing $collection_id"
+              echo "Publishing $entity_type: $collection_id"
 
-              response=$(python3 ./scripts/promote_collection.py "$file" "staging")
+              response=$(python3 "$script_to_run" "$file" "staging")
               echo "Processed file: $file"
               status_code=$(echo "$response" | jq -r '.statusCode' | head -n1)
               echo "Status Code: $status_code"
@@ -130,12 +145,12 @@ jobs:
               # Update status message based on response code
               if [[ $status_code -eq 200 ]] || [[ $status_code -eq 201 ]]; then
                 echo "$collection_id successfully published ✅"
-                status_message+="➡️ **$collection_id**: Successfully published ✅ <br>"
+                status_message+="➡️ **$collection_id** ($entity_type): Successfully published ✅ <br>"
                 success_collections+=("$file")
                 all_failed=false
               else
                 echo "$collection_id failed to publish ❌"
-                status_message+="➡️ **$collection_id**: Failed to publish. Error code $status_code. ❌<br>"
+                status_message+="➡️ **$collection_id** ($entity_type): Failed to publish. Error code $status_code. ❌<br>"
               fi
             else
               echo "File $file does not exist"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -124,18 +124,18 @@ jobs:
                 script_to_run="./scripts/promote_dataset.py"
                 # Datasets are required to have a `collection` field in their config
                 collection_id=$(jq -r '.collection' "$file")
-                entity_type="Dataset"
+                config_type="Dataset"
               elif [[ "$file" == ingestion-data/staging/collections/* ]]; then
                 script_to_run="./scripts/promote_collection.py"
                 # Collections are required to have an `id` field
                 collection_id=$(jq -r '.id' "$file")
-                entity_type="Collection"
+                config_type="Collection"
               else
-                echo "File $file is not in a recognized directory for ingestion (dataset-config or collections). Skipping."
+                echo "File $file is not in a recognized directory for promotion (dataset-config or collections). Skipping."
                 continue
               fi
 
-              echo "Publishing $entity_type: $collection_id"
+              echo "Publishing $config_type: $collection_id"
 
               response=$(python3 "$script_to_run" "$file" "staging")
               echo "Processed file: $file"
@@ -145,12 +145,12 @@ jobs:
               # Update status message based on response code
               if [[ $status_code -eq 200 ]] || [[ $status_code -eq 201 ]]; then
                 echo "$collection_id successfully published ✅"
-                status_message+="➡️ **$collection_id** ($entity_type): Successfully published ✅ <br>"
+                status_message+="➡️ **$collection_id** ($config_type): Successfully published ✅ <br>"
                 success_collections+=("$file")
                 all_failed=false
               else
                 echo "$collection_id failed to publish ❌"
-                status_message+="➡️ **$collection_id** ($entity_type): Failed to publish. Error code $status_code. ❌<br>"
+                status_message+="➡️ **$collection_id** ($config_type): Failed to publish. Error code $status_code. ❌<br>"
               fi
             else
               echo "File $file does not exist"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -74,22 +74,22 @@ jobs:
             if jq -e '.collection' "$file" > /dev/null; then
               script_to_run="./scripts/promote_dataset.py"
               collection_id=$(jq -r '.collection' "$file")
-              entity_type="Dataset"
+              config_type="Dataset"
             else
               script_to_run="./scripts/promote_collection.py"
               collection_id=$(jq -r '.id' "$file")
-              entity_type="Collection"
+              config_type="Collection"
             fi
 
-            echo "Promoting $entity_type ($collection_id) to production"
+            echo "Promoting $config_type ($collection_id) to production"
             response=$(python3 "$script_to_run" "$file" "production")
 
             echo "Processed file: $file"
             status_code=$(echo "$response" | jq -r '.statusCode')
             echo "Status Code: $status_code"
              if [ "$status_code" -eq 200 ] || [ "$status_code" -eq 201 ]; then
-                echo "$collection_id ($entity_type) successfully promoted to Production ✅"
+                echo "$collection_id ($config_type) successfully promoted to Production ✅"
               else
-                echo "$collection_id ($entity_type) failed to promote to Production ❌"
+                echo "$collection_id ($config_type) failed to promote to Production ❌"
               fi
           done

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -69,14 +69,27 @@ jobs:
         run: |
           pip install -r ./scripts/requirements.txt
           for file in downloaded-files/*.json; do
-            collection_id=$(jq -r '.collection' "$file")
-            response=$(python3 ./scripts/promote_collection.py "$file" "production")
+            echo "Processing $file"
+            # Check if collection key exists to determine if it's a dataset or collection
+            if jq -e '.collection' "$file" > /dev/null; then
+              script_to_run="./scripts/promote_dataset.py"
+              collection_id=$(jq -r '.collection' "$file")
+              entity_type="Dataset"
+            else
+              script_to_run="./scripts/promote_collection.py"
+              collection_id=$(jq -r '.id' "$file")
+              entity_type="Collection"
+            fi
+
+            echo "Promoting $entity_type ($collection_id) to production"
+            response=$(python3 "$script_to_run" "$file" "production")
+
             echo "Processed file: $file"
             status_code=$(echo "$response" | jq -r '.statusCode')
             echo "Status Code: $status_code"
-             if [ $status_code -eq 200 ] || [ $status_code -eq 201 ]; then
-                echo "$collection_id successfully promoted to Production ✅"
+             if [ "$status_code" -eq 200 ] || [ "$status_code" -eq 201 ]; then
+                echo "$collection_id ($entity_type) successfully promoted to Production ✅"
               else
-                echo "$collection_id failed to promote to Production ❌"
+                echo "$collection_id ($entity_type) failed to promote to Production ❌"
               fi
           done

--- a/scripts/promote_collection.py
+++ b/scripts/promote_collection.py
@@ -8,44 +8,36 @@ import uuid
 from base64 import b64encode
 
 
-class MissingFieldError(Exception):
-    pass
+def trigger_collection_dag(payload: Dict[str, Any], stage: str):
+    """
+    Triggers the veda_collection_pipeline DAG in either staging or production SM2A.
+    """
+    dag_name = "veda_collection_pipeline"
 
+    if stage == "staging":
+        api_url_env = "STAGING_SM2A_API_URL"
+        username_env = "STAGING_SM2A_ADMIN_USERNAME"
+        password_env = "STAGING_SM2A_ADMIN_PASSWORD"
+    elif stage == "production":
+        api_url_env = "SM2A_API_URL"
+        username_env = "SM2A_ADMIN_USERNAME"
+        password_env = "SM2A_ADMIN_PASSWORD"
+    else:
+        raise ValueError(
+            f"Invalid stage provided: {stage}. Must be 'staging' or 'production'."
+        )
 
-def validate_discovery_item_config(item: Dict[str, Any]) -> Dict[str, Any]:
-    if "bucket" not in item:
-        raise MissingFieldError(
-            "Missing required field 'bucket' in discovery item: {item}"
-        )
-    if "discovery" not in item:
-        raise MissingFieldError(
-            "Missing required field 'discovery' in discovery item: {item}"
-        )
-    if "filename_regex" not in item:
-        raise MissingFieldError(
-            "Missing required field 'filename_regex' in discovery item: {item}"
-        )
-    if "prefix" not in item:
-        raise MissingFieldError(
-            "Missing required field 'prefix' in discovery item: {item}"
-        )
-    return item
+    base_api_url = os.getenv(api_url_env)
+    username = os.getenv(username_env)
+    password = os.getenv(password_env)
 
-
-def publish_to_staging(payload):
-    base_api_url = os.getenv("STAGING_SM2A_API_URL")
-    dataset_pipeline_dag = os.getenv("DATASET_DAG_NAME", "veda_dataset_pipeline")
-    username = os.getenv("STAGING_SM2A_ADMIN_USERNAME")
-    password = os.getenv("STAGING_SM2A_ADMIN_PASSWORD")
+    if not all([base_api_url, username, password]):
+        raise ValueError(
+            f"Missing one or more environment variables: {api_url_env}, "
+            f"{username_env}, {password_env}"
+        )
 
     api_token = b64encode(f"{username}:{password}".encode()).decode()
-
-    if not base_api_url or not api_token:
-        raise ValueError(
-            "STAGING_SM2A_API_URL or STAGING_SM2A_ADMIN_USERNAME"
-            + " or STAGING_SM2A_ADMIN_PASSWORD is not"
-            + " set in the environment variables."
-        )
 
     headers = {
         "Content-Type": "application/json",
@@ -54,53 +46,12 @@ def publish_to_staging(payload):
 
     body = {
         **payload,
-        "dag_run_id": f"{dataset_pipeline_dag}-{uuid.uuid4()}",
+        "dag_run_id": f"{dag_name}-{uuid.uuid4()}",
         "note": "Run from GitHub Actions veda-data",
     }
     http_conn = http.client.HTTPSConnection(base_api_url)
     http_conn.request(
-        "POST",
-        f"/api/v1/dags/{dataset_pipeline_dag}/dagRuns",
-        json.dumps(body),
-        headers,
-    )
-    response = http_conn.getresponse()
-    response_data = response.read()
-    http_conn.close()
-
-    print(json.dumps({"statusCode": response.status}))
-    print(response_data.decode())
-    return {"statusCode": response.status, "body": response_data.decode()}
-
-
-def promote_to_production(payload):
-    base_api_url = os.getenv("SM2A_API_URL")
-    promotion_dag = os.getenv("PROMOTION_DAG_NAME", "veda_promotion_pipeline")
-    username = os.getenv("SM2A_ADMIN_USERNAME")
-    password = os.getenv("SM2A_ADMIN_PASSWORD")
-
-    api_token = b64encode(f"{username}:{password}".encode()).decode()
-
-    if not base_api_url or not api_token:
-        raise ValueError(
-            "SM2A_API_URL or SM2A_ADMIN_USERNAME or SM2A_ADMIN_PASSWORD is not"
-            + " set in the environment variables."
-        )
-
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": "Basic " + api_token,
-    }
-
-    payload["conf"]["transfer"] = True
-    body = {
-        **payload,
-        "dag_run_id": f"{promotion_dag}-{uuid.uuid4()}",
-        "note": "Run from GitHub Actions veda-data",
-    }
-    http_conn = http.client.HTTPSConnection(base_api_url)
-    http_conn.request(
-        "POST", f"/api/v1/dags/{promotion_dag}/dagRuns", json.dumps(body), headers
+        "POST", f"/api/v1/dags/{dag_name}/dagRuns", json.dumps(body), headers
     )
     response = http_conn.getresponse()
     response_data = response.read()
@@ -114,17 +65,10 @@ def promote_to_production(payload):
 if __name__ == "__main__":
     try:
         with open(sys.argv[1], "r") as file:
-            input = json.load(file)
+            input_data = json.load(file)
             stage = sys.argv[2]
-            discovery_items = input.get("discovery_items")
-            validated_discovery_items = [
-                validate_discovery_item_config(item) for item in discovery_items
-            ]
-            dag_payload = {"conf": input}
-            if stage == "production":
-                promote_to_production(dag_payload)
-            elif stage == "staging":
-                publish_to_staging(dag_payload)
+            dag_payload = {"conf": input_data}
+            trigger_collection_dag(dag_payload, stage)
 
     except IndexError:
         print("Usage: promote_collection.py <file_name> <stage>")

--- a/scripts/promote_dataset.py
+++ b/scripts/promote_dataset.py
@@ -1,0 +1,134 @@
+from typing import Dict, Any
+
+import http.client
+import json
+import sys
+import os
+import uuid
+from base64 import b64encode
+
+
+class MissingFieldError(Exception):
+    pass
+
+
+def validate_discovery_item_config(item: Dict[str, Any]) -> Dict[str, Any]:
+    if "bucket" not in item:
+        raise MissingFieldError(
+            "Missing required field 'bucket' in discovery item: {item}"
+        )
+    if "discovery" not in item:
+        raise MissingFieldError(
+            "Missing required field 'discovery' in discovery item: {item}"
+        )
+    if "filename_regex" not in item:
+        raise MissingFieldError(
+            "Missing required field 'filename_regex' in discovery item: {item}"
+        )
+    if "prefix" not in item:
+        raise MissingFieldError(
+            "Missing required field 'prefix' in discovery item: {item}"
+        )
+    return item
+
+
+def publish_to_staging(payload):
+    base_api_url = os.getenv("STAGING_SM2A_API_URL")
+    dataset_pipeline_dag = os.getenv("DATASET_DAG_NAME", "veda_dataset_pipeline")
+    username = os.getenv("STAGING_SM2A_ADMIN_USERNAME")
+    password = os.getenv("STAGING_SM2A_ADMIN_PASSWORD")
+
+    api_token = b64encode(f"{username}:{password}".encode()).decode()
+
+    if not base_api_url or not api_token:
+        raise ValueError(
+            "STAGING_SM2A_API_URL or STAGING_SM2A_ADMIN_USERNAME"
+            + " or STAGING_SM2A_ADMIN_PASSWORD is not"
+            + " set in the environment variables."
+        )
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Basic " + api_token,
+    }
+
+    body = {
+        **payload,
+        "dag_run_id": f"{dataset_pipeline_dag}-{uuid.uuid4()}",
+        "note": "Run from GitHub Actions veda-data",
+    }
+    http_conn = http.client.HTTPSConnection(base_api_url)
+    http_conn.request(
+        "POST",
+        f"/api/v1/dags/{dataset_pipeline_dag}/dagRuns",
+        json.dumps(body),
+        headers,
+    )
+    response = http_conn.getresponse()
+    response_data = response.read()
+    http_conn.close()
+
+    print(json.dumps({"statusCode": response.status}))
+    print(response_data.decode())
+    return {"statusCode": response.status, "body": response_data.decode()}
+
+
+def promote_to_production(payload):
+    base_api_url = os.getenv("SM2A_API_URL")
+    promotion_dag = os.getenv("PROMOTION_DAG_NAME", "veda_promotion_pipeline")
+    username = os.getenv("SM2A_ADMIN_USERNAME")
+    password = os.getenv("SM2A_ADMIN_PASSWORD")
+
+    api_token = b64encode(f"{username}:{password}".encode()).decode()
+
+    if not base_api_url or not api_token:
+        raise ValueError(
+            "SM2A_API_URL or SM2A_ADMIN_USERNAME or SM2A_ADMIN_PASSWORD is not"
+            + " set in the environment variables."
+        )
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Basic " + api_token,
+    }
+
+    payload["conf"]["transfer"] = True
+    body = {
+        **payload,
+        "dag_run_id": f"{promotion_dag}-{uuid.uuid4()}",
+        "note": "Run from GitHub Actions veda-data",
+    }
+    http_conn = http.client.HTTPSConnection(base_api_url)
+    http_conn.request(
+        "POST", f"/api/v1/dags/{promotion_dag}/dagRuns", json.dumps(body), headers
+    )
+    response = http_conn.getresponse()
+    response_data = response.read()
+    http_conn.close()
+
+    print(json.dumps({"statusCode": response.status}))
+    print(response_data.decode())
+    return {"statusCode": response.status, "body": response_data.decode()}
+
+
+if __name__ == "__main__":
+    try:
+        with open(sys.argv[1], "r") as file:
+            input = json.load(file)
+            stage = sys.argv[2]
+            discovery_items = input.get("discovery_items")
+            validated_discovery_items = [
+                validate_discovery_item_config(item) for item in discovery_items
+            ]
+            dag_payload = {"conf": input}
+            if stage == "production":
+                promote_to_production(dag_payload)
+            elif stage == "staging":
+                publish_to_staging(dag_payload)
+
+    except IndexError:
+        print("Usage: promote_collection.py <file_name> <stage>")
+    except FileNotFoundError:
+        print(f"Error: File '{sys.argv[1]}' not found.")
+    except json.JSONDecodeError:
+        raise ValueError(f"Invalid JSON content in file {sys.argv[1]}")


### PR DESCRIPTION
## Description

- renames `promote_collection.py` as `promote_dataset.py`. New `promote_collection.py` now includes a script to post to the `veda_collection_pipeline` DAG. Dataset promotion scripts which is now in `promote_dataset.py` is unchanged.
- `pr.yml` and `promote.yml` include logic for both `ingestion-data/staging/dataset-config/` and `ingestion-data/staging/collections/` directories