### PR TITLE
fix: remove print user info

### DIFF
--- a/scripts/promote_collection.py
+++ b/scripts/promote_collection.py
@@ -33,8 +33,10 @@ def trigger_collection_dag(payload: Dict[str, Any], stage: str):
 
     if not all([base_api_url, username, password]):
         raise ValueError(
-            f"Missing one or more environment variables: stage undefined={stage==None}, "
-            f"username undefined={username_env==None}, password undefined={password_env==None}"
+            f"Missing one or more environment variables: "
+            f"stage is None={stage is None}, "
+            f"username is None={username_env is None}, "
+            f"password is None={password_env is None}"
         )
 
     api_token = b64encode(f"{username}:{password}".encode()).decode()

--- a/scripts/promote_collection.py
+++ b/scripts/promote_collection.py
@@ -33,8 +33,8 @@ def trigger_collection_dag(payload: Dict[str, Any], stage: str):
 
     if not all([base_api_url, username, password]):
         raise ValueError(
-            f"Missing one or more environment variables: {api_url_env}, "
-            f"{username_env}, {password_env}"
+            f"Missing one or more environment variables: stage undefined={stage==None}, "
+            f"username undefined={username_env==None}, password undefined={password_env==None}"
         )
 
     api_token = b64encode(f"{username}:{password}".encode()).decode()


### PR DESCRIPTION
## What
Do print informative statement if env variables are missing but do not print values

## How Tested
```
>>> stage="production"
>>> username_env=None
>>> password_env="pants"                                                                                                   
>>> print(f"Missing one or more environment variables: stage undefined={stage==None}, username undefined={username_env==None}, password undefined={password_env==None}")

Missing one or more environment variables: stage undefined=False, username undefined=True, password undefined=False
```