### PR TITLE
ci: replace `tj-actions`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,8 @@
 # This GitHub Actions workflow automates the process of
 # publishing dataset collections to a staging environment
 # It is triggered by a pull request to the main branch
-# that modifies any files within the ingestion-data/dataset-config/ directory
+# that modifies any JSON files within the specified
+# ingestion-data/staging/ subdirectories
 # The workflow includes steps to
 #   - publish the datasets,
 #   - constantly updates the status of the workflow in the PR comment
@@ -70,11 +71,16 @@ jobs:
       # The files are outputted to GITHUB_OUTPUT, which can be used in subsequent steps
       - name: Get newly added and changed files
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
-        with:
-          files: |
-            ingestion-data/staging/dataset-config/**.json
-            ingestion-data/staging/collections/**.json
+        run: |
+          ACMR_FILES=$(git diff --name-only --diff-filter=ACMR $GITHUB_BASE_REF...$GITHUB_HEAD_REF)
+
+          mapfile -t "PUBLISH_FILES" < <(echo "$ACMR_FILES" | grep \
+            -e "^ingestion-data/staging/dataset-config/.*\.json$" \
+            -e "^ingestion-data/staging/collections/.*\.json$"
+          )
+
+          echo "all_changed_files=${PUBLISH_FILES[*]}" >> $GITHUB_OUTPUT
+          echo "all_changed_files_count=${#PUBLISH_FILES[@]}" >> $GITHUB_OUTPUT
 
       # ACMR - Added, Copied, Modified, Renamed
       - name: List all newly added and changed files


### PR DESCRIPTION
## What I am changing

Replace [@tj-actions/changed-files](https://github.com/tj-actions/changed-files)

Addresses https://github.com/NASA-IMPACT/veda-architecture/issues/570

NOTE: The workflow trigger uses a glob pattern match (`ingestion-data/staging/dataset-config/**.json`), whereas the current bash uses a regex pattern match (`^ingestion-data/staging/dataset-config/.*\.json$`)
- **Alternative**
    - Append [path](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-path) globs to the `diff` cmd
    - [git diff [\<options\>] \<commit\>..\<commit\> [--] [\<path\>…​]](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-gitdiffoptionscommitcommit--path)
- **Considerations**: 
    - The git-based alternative could be easier to misapply + fail silently (e.g. shell expansion, pattern validation) 

## How I did it

- Align with `tj-actions` behavior
    - Identify changed files, excluding full deletions
    - Surface only the new name on file renames
    - Add files + count to output
    - Verify coverage on any branching codepaths

## How you can test it

Locally, via [act](https://github.com/nektos/act)

1. Pull down this branch + branch off of it
1. Commit a change outside of the target filepaths (e.g. an edit in ingestion-data/staging/**discovery-items**/, a top-level CONTRIBUTING.md add)
1. Run act, being sure to pass in [event information](https://nektosact.com/usage/index.html#using-event-file-to-provide-complete-event-payload) required for the workflow
    1. ```sh
        $ act pull_request -W .github/workflows/pr.yml -e ./event.json
        # ...
        # [Publish collection to staging/publish-new-datasets] ⚙ ::set-output:: all_changed_files=
        # [Publish collection to staging/publish-new-datasets] ⚙ ::set-output:: all_changed_files_count=0
        ```
        Expect → changed files not to flag for publication
        Expect → exit early condition to pass
        
1. Commit several change types (adds, edits, renames, deletes, etc.) throughout the repo, with at least one in the target filepath(s), and rerun act
    1. ```sh
        $ act pull_request -W .github/workflows/pr.yml -e ./event.json
        # ...
        # [Publish collection to staging/publish-new-datasets] ⚙ ::set-output:: all_changed_files=ingestion-data/staging/dataset-config/x.json ingestion-data/staging/collections/y.json
        # [Publish collection to staging/publish-new-datasets] ⚙ ::set-output:: all_changed_files_count=2
        ```
        Expect → added, copied, modified, renamed files in the target filepaths to flag for publication
        Expect → deleted files in the target filepaths **not** to flag for publication
        Expect → data types, expression evaluation to remain consistent (e.g. file list is still iterable, file count is still expected to be a number)