### PR TITLE
feat(scheduled-dags): add currently scheduled vector ingest configs

### DIFF
--- a/ingestion-data/production/discovery-items/scheduled/eis-fedsoutput-lfarchive.json
+++ b/ingestion-data/production/discovery-items/scheduled/eis-fedsoutput-lfarchive.json
@@ -1,0 +1,12 @@
+{
+    "bucket": "veda-data-store-staging",
+    "discovery": "s3",
+    "collection": "eis-fedsoutput-lfarchive",
+    "filename_regex": "^(.*)lf_(perimeter|fireline|newfirepix)_nrt_(conus|borealna|russiaeast).gpkg$",
+    "prefix": "EIS/FEDSoutput/LFArchive/",
+    "vector": true,
+    "id_template": "{}",
+    "schedule": "*/15 * * * *",
+    "dag": "veda_ingest_vector",
+    "invalidate_cloudfront": true
+  }

--- a/ingestion-data/production/discovery-items/scheduled/eis-fedsoutput-snapshot.json
+++ b/ingestion-data/production/discovery-items/scheduled/eis-fedsoutput-snapshot.json
@@ -1,0 +1,12 @@
+{
+    "bucket": "veda-data-store-staging",
+    "discovery": "s3",
+    "collection": "eis-fedsoutput-snapshot",
+    "filename_regex": "^(.*)snapshot_perimeter_nrt_(conus|borealna|russiaeast).gpkg$",
+    "prefix": "EIS/FEDSoutput/Snapshot/",
+    "vector": true,
+    "id_template": "{}",
+    "schedule": "*/15 * * * *",
+    "dag": "veda_ingest_vector",
+    "invalidate_cloudfront": true
+  }


### PR DESCRIPTION
## What
This PR adds the configs currently used to schedule production vector ingests.