### PR TITLE
Update GEDI WMTS collection

### DIFF
--- a/ingestion-data/staging/collections/GEDI_ISS_L3_Canopy_Height_Mean_RH100_201904-202303.json
+++ b/ingestion-data/staging/collections/GEDI_ISS_L3_Canopy_Height_Mean_RH100_201904-202303.json
@@ -27,14 +27,11 @@
   "license": "CC0-1.0",
   "links": [
     {
-      "href": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
+      "href": "https://gibs{s}.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
       "rel": "wmts",
       "type": "image/png",
       "title": "Visualized through a WMTS",
-      "href:servers": [
-        "https://gibs-a.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
-        "https://gibs-b.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi"
-      ],
+      "href:servers": [ "-a", "-b"],
       "wmts:dimensions": {
         "STYLE": "default"
       },
@@ -69,7 +66,6 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/render/v1.0.0/schema.json",
     "https://stac-extensions.github.io/web-map-links/v1.2.0/schema.json"
   ],
   "stac_version": "1.0.0",


### PR DESCRIPTION
## Summary

To properly validate STAC collection using the [stac-validator](https://github.com/stac-utils/stac-validator), removal of `renders` was necessary since there was no metadata used for the `renders` extension. Additionally, changing the `href:servers` was necessary.  This now creates a valid STAC items with the singular `web-map-links` extension.

I open this thread for additional discussion.