### PR TITLE
ci: pin checkout to sha aligning with all other uses

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -272,7 +272,7 @@ jobs:
       skip_mdx_pr_step: ${{ steps.skip_mdx_pr_step_setting.outputs.skip_mdx_pr_step }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set SKIP_MDX_PR_STEP condition
         id: skip_mdx_pr_step_setting


### PR DESCRIPTION
Addresses #439

Uses same SHA as all other checkouts