### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,6 @@ on:
       - main
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:
@@ -34,6 +33,8 @@ jobs:
       published_collections: ${{ steps.publish-collections.outputs.success_collections }}
       comment_id: ${{ steps.init-comment.outputs.COMMENT_ID }}
       has_new_files_to_promote: ${{ steps.changed-files.outputs.all_changed_files_count != 0 }}
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -287,6 +288,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     needs: ['mdx-pr-flag-evaluator', 'publish-new-datasets']
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,7 +1,6 @@
 name: Publish collection to production
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -43,6 +42,8 @@ jobs:
     needs: validate-trigger-token-and-pr-number
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/promotion-checker.yml
+++ b/.github/workflows/promotion-checker.yml
@@ -9,7 +9,6 @@ on:
       - ingestion-data/staging/collections/*.json
 
 permissions:
-    actions: write
     contents: read
 
 jobs:
@@ -51,6 +50,8 @@ jobs:
   trigger-promotion-workflow:
     runs-on: ubuntu-latest
     needs: check-conditions
+    permissions:
+      actions: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
>[!NOTE]
>See https://github.com/NASA-IMPACT/veda-keycloak/pull/253 for more detail on OSSF Scorecard + Dependabot configs, removed repeated detail to help reviewers and better highlight repo-specific deltas.

---

- Dependabot version updates added:
    - `pip` (deploy script dependencies)
    - `github-actions` (CI)
- [OSSF Scorecard](https://github.com/ossf/scorecard-action) added
- Token permissions
    - Move write permissions from top-level (all jobs) to specific job required